### PR TITLE
Reintroduce metadata + fixes

### DIFF
--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -6,7 +6,7 @@
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"http://schema.org","@type":"TechArticle","url":"https://w3id.org/fso#","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://w3id.org/fso#","name":"The Fluid Systems Ontology (FSO)", "headline":"Some description in english", "datePublished":"2019-11-06T12:00:00", "version":"0.0.1", "license":"https://creativecommons.org/licenses/by/1.0/", "author":[{"@type":"Person","name":"Ali Kücükavci"},{"@type":"Person","name":"Mads Holten Rasmussen"},{"@type":"Person","name":"Ville Kukkonen"}], "contributor":[{"@type":"Person","name":"All contributing members of the W3C Linked Building Data Community Group"}]}</script>
+<script type="application/ld+json">{"@context":"http://schema.org","@type":"TechArticle","url":"https://w3id.org/fso#","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://w3id.org/fso#","name":"The Fluid Systems Ontology (FSO)", "headline":"Some description in english", "datePublished":"2019-11-06T12:00:00", "version":"0.0.1", "license":"https://creativecommons.org/licenses/by/1.0/", "author":[{"@type":"Person","name":"https://orcid.org/0000-0002-6519-7057","url":"https://orcid.org/0000-0002-6519-7057"},{"@type":"Person","name":"Ali Kücükavci"},{"@type":"Person","name":"Mads Holten Rasmussen"},{"@type":"Person","name":"Ville Kukkonen"}], "contributor":[{"@type":"Person","name":"All contributing members of the W3C Linked Building Data Community Group"}]}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 
@@ -64,7 +64,7 @@ function loadTOC(){
 <dt>Revision:</dt>
 <dd>0.0.1</dd>
 <dt>Authors:</dt>
-<dd>Ali Kücükavci</dd><dd>Mads Holten Rasmussen</dd><dd>Ville Kukkonen</dd>
+<dd><a href="https://orcid.org/0000-0002-6519-7057">https://orcid.org/0000-0002-6519-7057</a></dd><dd>Ali Kücükavci</dd><dd>Mads Holten Rasmussen</dd><dd>Ville Kukkonen</dd>
 
 <dt>Contributors:</dt>
 <dd>All contributing members of the W3C Linked Building Data Community Group</dd>
@@ -72,7 +72,7 @@ function loadTOC(){
 <dt>Download serialization:</dt><dd><span><a href="ontology.json" target="_blank"><img src="https://img.shields.io/badge/Format-JSON_LD-blue.svg" alt="JSON-LD" /></a> </span><span><a href="ontology.xml" target="_blank"><img src="https://img.shields.io/badge/Format-RDF/XML-blue.svg" alt="RDF/XML" /></a> </span><span><a href="ontology.nt" target="_blank"><img src="https://img.shields.io/badge/Format-N_Triples-blue.svg" alt="N-Triples" /></a> </span><span><a href="ontology.ttl" target="_blank"><img src="https://img.shields.io/badge/Format-TTL-blue.svg" alt="TTL" /></a> </span></dd><dt>License: </dt><dd><a href="https://creativecommons.org/licenses/by/1.0/" target="_blank"><img src="https://img.shields.io/badge/License-https://creativecommons.org/licenses/by/1.0/-blue.svg" alt="https://creativecommons.org/licenses/by/1.0/" /></a>
 </dd><dt>Visualization:</dt><dd><a href="webvowl/index.html#" target="_blank"><img src="https://img.shields.io/badge/Visualize_with-WebVowl-blue.svg" alt="Visualize with WebVowl" /></a></dd>
 <dt>Cite as:</dt>
-<dd>Ali Kücükavci,Mads Holten Rasmussen,Ville Kukkonen. The Fluid Systems Ontology (FSO). Revision: 0.0.1. Retrieved from: https://w3id.org/fso/0.0.1</dd>
+<dd>https://orcid.org/0000-0002-6519-7057,Ali Kücükavci,Mads Holten Rasmussen,Ville Kukkonen. The Fluid Systems Ontology (FSO). Revision: 0.0.1. Retrieved from: https://w3id.org/fso/0.0.1</dd>
 </dl>
 
 <a href="provenance/provenance-en.html" target="_blank">Provenance of this page</a><hr/>
@@ -97,18 +97,15 @@ This is a place holder text for the introduction. The introduction should briefl
 <caption> <a href="#ns"> Table 1</a>: Namespaces used in the document </caption>
 <tbody>
 <tr><td><b>fso</b></td><td>&lt;https://w3id.org/fso#&gt;</td></tr>
-<tr><td><b>schema</b></td><td>&lt;http://schema.org&gt;</td></tr>
 <tr><td><b>fso</b></td><td>&lt;https://w3id.org/fso&gt;</td></tr>
-<tr><td><b>ns</b></td><td>&lt;http://www.w3.org/2003/06/sw-vocab-status/ns&gt;</td></tr>
 <tr><td><b>owl</b></td><td>&lt;http://www.w3.org/2002/07/owl&gt;</td></tr>
+<tr><td><b>rdf</b></td><td>&lt;http://www.w3.org/1999/02/22-rdf-syntax-ns&gt;</td></tr>
+<tr><td><b>terms</b></td><td>&lt;http://purl.org/dc/terms&gt;</td></tr>
 <tr><td><b>xsd</b></td><td>&lt;http://www.w3.org/2001/XMLSchema&gt;</td></tr>
 <tr><td><b>voaf</b></td><td>&lt;http://purl.org/vocommons/voaf&gt;</td></tr>
 <tr><td><b>rdfs</b></td><td>&lt;http://www.w3.org/2000/01/rdf-schema&gt;</td></tr>
-<tr><td><b>orcid-org</b></td><td>&lt;https://orcid.org&gt;</td></tr>
-<tr><td><b>0-1</b></td><td>&lt;http://xmlns.com/foaf/0.1&gt;</td></tr>
-<tr><td><b>rdf</b></td><td>&lt;http://www.w3.org/1999/02/22-rdf-syntax-ns&gt;</td></tr>
-<tr><td><b>terms</b></td><td>&lt;http://purl.org/dc/terms&gt;</td></tr>
 <tr><td><b>vann</b></td><td>&lt;http://purl.org/vocab/vann&gt;</td></tr>
+<tr><td><b>orcid-org</b></td><td>&lt;https://orcid.org&gt;</td></tr>
 <tr><td><b>default namespace</b></td><td>&lt;https://w3id.org/fso&gt;</td></tr>
 </tbody>
 </table>
@@ -124,24 +121,59 @@ This ontology has the following classes and properties.</span>
 <h4>Classes</h4>
 <ul class="hlist">
    <li>
-      <a href="#HeatExchanger" title="https://w3id.org/fso#HeatExchanger">Heat Exchanger</a>
+      <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
    </li>
    <li>
-      <a href="#returnsFluidTo" title="https://w3id.org/fso#returnsFluidTo">
-         <span>returns fluid to</span>
-      </a>
+      <a href="#DistributionSystem" title="https://w3id.org/fso#DistributionSystem">Distribution system</a>
    </li>
    <li>
-      <a href="#suppliesFluidTo" title="https://w3id.org/fso#suppliesFluidTo">
-         <span>supplies fluid to</span>
-      </a>
+      <a href="#EnergyConversionDevice" title="https://w3id.org/fso#EnergyConversionDevice">Energy conversion device</a>
+   </li>
+   <li>
+      <a href="#Fitting" title="https://w3id.org/fso#Fitting">Fitting</a>
+   </li>
+   <li>
+      <a href="#FlowController" title="https://w3id.org/fso#FlowController">Flow controller</a>
+   </li>
+   <li>
+      <a href="#FlowMovingDevice" title="https://w3id.org/fso#FlowMovingDevice">Flow moving device</a>
+   </li>
+   <li>
+      <a href="#Fluid" title="https://w3id.org/fso#Fluid">Fluid</a>
+   </li>
+   <li>
+      <a href="#MonitoringDevice" title="https://w3id.org/fso#MonitoringDevice">Fluid monitoring device</a>
+   </li>
+   <li>
+      <a href="#Material" title="https://w3id.org/fso#Material">Material</a>
+   </li>
+   <li>
+      <a href="#ReturnSystem" title="https://w3id.org/fso#ReturnSystem">Return system</a>
+   </li>
+   <li>
+      <a href="#Segment" title="https://w3id.org/fso#Segment">Segment</a>
+   </li>
+   <li>
+      <a href="#StorageDevice" title="https://w3id.org/fso#StorageDevice">Storage device</a>
+   </li>
+   <li>
+      <a href="#SupplySystem" title="https://w3id.org/fso#SupplySystem">Supply system</a>
    </li>
    <li>
       <a href="#System" title="https://w3id.org/fso#System">System</a>
    </li>
+   <li>
+      <a href="#Terminal" title="https://w3id.org/fso#Terminal">Terminal</a>
+   </li>
+   <li>
+      <a href="#TreatmentDevice" title="https://w3id.org/fso#TreatmentDevice">Treatment device</a>
+   </li>
 </ul><h4>Object Properties</h4><ul class="hlist">
    <li>
-      <a href="#fedBy" title="https://w3id.org/fso#fedBy">fed by</a>
+      <a href="#exchangesFluidWith" title="https://w3id.org/fso#exchangesFluidWith">exchanges fluid with</a>
+   </li>
+   <li>
+      <a href="#exchangesHeatWith" title="https://w3id.org/fso#exchangesHeatWith">exchanges heat with</a>
    </li>
    <li>
       <a href="#feeds" title="https://w3id.org/fso#feeds">
@@ -150,6 +182,53 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#hasComponent" title="https://w3id.org/fso#hasComponent">has component</a>
+   </li>
+   <li>
+      <a href="#hasDensity" title="https://w3id.org/fso#hasDensity">has density</a>
+   </li>
+   <li>
+      <a href="#hasFluid" title="https://w3id.org/fso#hasFluid">has fluid</a>
+   </li>
+   <li>
+      <a href="#hasHeatCapacity" title="https://w3id.org/fso#hasHeatCapacity">has heat capacity</a>
+   </li>
+   <li>
+      <a href="#hasMassFlow" title="https://w3id.org/fso#hasMassFlow">has mass flow</a>
+   </li>
+   <li>
+      <a href="#hasPowerOutput" title="https://w3id.org/fso#hasPowerOutput">
+         <span>has power output</span>
+      </a>
+   </li>
+   <li>
+      <a href="#hasProperty" title="https://w3id.org/fso#hasProperty">has property</a>
+   </li>
+   <li>
+      <a href="#hasReturnSystem" title="https://w3id.org/fso#hasReturnSystem">has return system</a>
+   </li>
+   <li>
+      <a href="#hasReturnTemperature" title="https://w3id.org/fso#hasReturnTemperature">has return temperature</a>
+   </li>
+   <li>
+      <a href="#hasSubSystem" title="https://w3id.org/fso#hasSubSystem">has subsystem</a>
+   </li>
+   <li>
+      <a href="#hasSupplySystem" title="https://w3id.org/fso#hasSupplySystem">has supply system</a>
+   </li>
+   <li>
+      <a href="#hasSupplyTemperature" title="https://w3id.org/fso#hasSupplyTemperature">has supply temperature</a>
+   </li>
+   <li>
+      <a href="#hasTemperature" title="https://w3id.org/fso#hasTemperature">has temperature</a>
+   </li>
+   <li>
+      <a href="#isMadeOfMaterial" title="https://w3id.org/fso#isMadeOfMaterial">is made of material</a>
+   </li>
+   <li>
+      <a href="#returnsFluidTo" title="https://w3id.org/fso#returnsFluidTo">returns fluid to</a>
+   </li>
+   <li>
+      <a href="#suppliesFluidTo" title="https://w3id.org/fso#suppliesFluidTo">supplies fluid to</a>
    </li>
 </ul><h4>Annotation Properties</h4><ul class="hlist">
    <li>
@@ -165,11 +244,6 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://purl.org/dc/terms/description" title="http://purl.org/dc/terms/description">
          <span>description</span>
-      </a>
-   </li>
-   <li>
-      <a href="#http://schema.org/domainIncludes" title="http://schema.org/domainIncludes">
-         <span>domain includes</span>
       </a>
    </li>
    <li>
@@ -196,17 +270,6 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://purl.org/vocab/vann/preferredNamespaceUri" title="http://purl.org/vocab/vann/preferredNamespaceUri">
          <span>preferred namespace uri</span>
-      </a>
-   </li>
-   <li>
-      <a href="#http://schema.org/rangeIncludes" title="http://schema.org/rangeIncludes">
-         <span>range includes</span>
-      </a>
-   </li>
-   <li>
-      <a href="#http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"
-         title="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status">
-         <span>term status</span>
       </a>
    </li>
    <li>
@@ -239,77 +302,301 @@ This section provides details for each class and property defined by The Fluid S
    <h3 id="classes-headline" class="list">Classes</h3>
    <ul class="hlist">
       <li>
-         <a href="#HeatExchanger" title="https://w3id.org/fso#HeatExchanger">Heat Exchanger</a>
+         <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
       </li>
       <li>
-         <a href="#returnsFluidTo" title="https://w3id.org/fso#returnsFluidTo">
-            <span>returns fluid to</span>
-         </a>
+         <a href="#DistributionSystem" title="https://w3id.org/fso#DistributionSystem">Distribution system</a>
       </li>
       <li>
-         <a href="#suppliesFluidTo" title="https://w3id.org/fso#suppliesFluidTo">
-            <span>supplies fluid to</span>
-         </a>
+         <a href="#EnergyConversionDevice" title="https://w3id.org/fso#EnergyConversionDevice">Energy conversion device</a>
+      </li>
+      <li>
+         <a href="#Fitting" title="https://w3id.org/fso#Fitting">Fitting</a>
+      </li>
+      <li>
+         <a href="#FlowController" title="https://w3id.org/fso#FlowController">Flow controller</a>
+      </li>
+      <li>
+         <a href="#FlowMovingDevice" title="https://w3id.org/fso#FlowMovingDevice">Flow moving device</a>
+      </li>
+      <li>
+         <a href="#Fluid" title="https://w3id.org/fso#Fluid">Fluid</a>
+      </li>
+      <li>
+         <a href="#MonitoringDevice" title="https://w3id.org/fso#MonitoringDevice">Fluid monitoring device</a>
+      </li>
+      <li>
+         <a href="#Material" title="https://w3id.org/fso#Material">Material</a>
+      </li>
+      <li>
+         <a href="#ReturnSystem" title="https://w3id.org/fso#ReturnSystem">Return system</a>
+      </li>
+      <li>
+         <a href="#Segment" title="https://w3id.org/fso#Segment">Segment</a>
+      </li>
+      <li>
+         <a href="#StorageDevice" title="https://w3id.org/fso#StorageDevice">Storage device</a>
+      </li>
+      <li>
+         <a href="#SupplySystem" title="https://w3id.org/fso#SupplySystem">Supply system</a>
       </li>
       <li>
          <a href="#System" title="https://w3id.org/fso#System">System</a>
       </li>
+      <li>
+         <a href="#Terminal" title="https://w3id.org/fso#Terminal">Terminal</a>
+      </li>
+      <li>
+         <a href="#TreatmentDevice" title="https://w3id.org/fso#TreatmentDevice">Treatment device</a>
+      </li>
    </ul>
-   <div class="entity" id="HeatExchanger">
-      <h3>Heat Exchanger<sup class="type-c" title="class">c</sup>
+   <div class="entity" id="Component">
+      <h3>Component<sup class="type-c" title="class">c</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
          </span>
       </h3>
       <p>
-         <strong>IRI:</strong> https://w3id.org/fso#HeatExchanger</p>
+         <strong>IRI:</strong> https://w3id.org/fso#Component</p>
       <div class="comment">
-         <span class="markdown">A heat exchanger is a device designed to transfer energy from one medium to another. Examples of heat exchangers include radiators, heating coils, water/water heat exchangers and mixing plants.</span>
+         <span class="markdown">A component contained by a fso:System</span>
       </div>
       <dl class="description">
-         <dt>has super-classes</dt>
+         <dt>has sub-classes</dt>
          <dd>
-            <span class="dotted" title="https://w3id.org/fso#Element">element</span>
+            <a href="#EnergyConversionDevice" title="https://w3id.org/fso#EnergyConversionDevice">Energy conversion device</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#Fitting" title="https://w3id.org/fso#Fitting">Fitting</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#FlowController" title="https://w3id.org/fso#FlowController">Flow controller</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#FlowMovingDevice" title="https://w3id.org/fso#FlowMovingDevice">Flow moving device</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#MonitoringDevice" title="https://w3id.org/fso#MonitoringDevice">Fluid monitoring device</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#Segment" title="https://w3id.org/fso#Segment">Segment</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#StorageDevice" title="https://w3id.org/fso#StorageDevice">Storage device</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#Terminal" title="https://w3id.org/fso#Terminal">Terminal</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#TreatmentDevice" title="https://w3id.org/fso#TreatmentDevice">Treatment device</a>
             <sup class="type-c" title="class">c</sup>
          </dd>
-         <dt>is in domain of</dt>
+         <dt>is in range of</dt>
          <dd>
             <a href="#hasComponent" title="https://w3id.org/fso#hasComponent">has component</a>
             <sup class="type-op" title="object property">op</sup>
          </dd>
       </dl>
    </div>
-   <div class="entity" id="returnsFluidTo">
-      <h3>returns fluid to<sup class="type-c" title="class">c</sup>
+   <div class="entity" id="DistributionSystem">
+      <h3>Distribution system<sup class="type-c" title="class">c</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
          </span>
       </h3>
       <p>
-         <strong>IRI:</strong> https://w3id.org/fso#returnsFluidTo</p>
+         <strong>IRI:</strong> https://w3id.org/fso#DistributionSystem</p>
+      <div class="comment">
+         <span class="markdown">A system that distributes energy and/or mass</span>
+      </div>
       <dl class="description">
          <dt>has super-classes</dt>
          <dd>
-            <span class="dotted" title="https://w3id.org/fso#feeds">feeds</span>
+            <a href="#System" title="https://w3id.org/fso#System">System</a>
             <sup class="type-c" title="class">c</sup>
          </dd>
-         <dt>is also defined as</dt>
-         <dd>object property</dd>
+         <dt>has sub-classes</dt>
+         <dd>
+            <a href="#ReturnSystem" title="https://w3id.org/fso#ReturnSystem">Return system</a>
+            <sup class="type-c" title="class">c</sup>, <a href="#SupplySystem" title="https://w3id.org/fso#SupplySystem">Supply system</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
       </dl>
    </div>
-   <div class="entity" id="suppliesFluidTo">
-      <h3>supplies fluid to<sup class="type-c" title="class">c</sup>
+   <div class="entity" id="EnergyConversionDevice">
+      <h3>Energy conversion device<sup class="type-c" title="class">c</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
          </span>
       </h3>
       <p>
-         <strong>IRI:</strong> https://w3id.org/fso#suppliesFluidTo</p>
+         <strong>IRI:</strong> https://w3id.org/fso#EnergyConversionDevice</p>
+      <div class="comment">
+         <span class="markdown">A device that is used to convert energy from one form to another, or move it from one system to another. Potential examples include motors and heat exhangers.</span>
+      </div>
       <dl class="description">
          <dt>has super-classes</dt>
          <dd>
-            <span class="dotted" title="https://w3id.org/fso#feeds">feeds</span>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
             <sup class="type-c" title="class">c</sup>
          </dd>
-         <dt>is also defined as</dt>
-         <dd>object property</dd>
+      </dl>
+   </div>
+   <div class="entity" id="Fitting">
+      <h3>Fitting<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#Fitting</p>
+      <div class="comment">
+         <span class="markdown">A component used to connect segments to each other, or to other components. For example, a junction in a pipe system.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="FlowController">
+      <h3>Flow controller<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#FlowController</p>
+      <div class="comment">
+         <span class="markdown">A device that has the potential to control the flow in a network. For example, valves and dampers.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="FlowMovingDevice">
+      <h3>Flow moving device<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#FlowMovingDevice</p>
+      <div class="comment">
+         <span class="markdown">A device used to induce movement in a network. For example, pumps and fans.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="Fluid">
+      <h3>Fluid<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#Fluid</p>
+      <div class="comment">
+         <span class="markdown">A liquid or gaseous substance, for example water or some mixture</span>
+      </div>
+   </div>
+   <div class="entity" id="MonitoringDevice">
+      <h3>Fluid monitoring device<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#MonitoringDevice</p>
+      <div class="comment">
+         <span class="markdown">A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="Material">
+      <h3>Material<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#Material</p>
+      <div class="comment">
+         <span class="markdown">A substance</span>
+      </div>
+   </div>
+   <div class="entity" id="ReturnSystem">
+      <h3>Return system<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#ReturnSystem</p>
+      <div class="comment">
+         <span class="markdown">A system that returns energy and/or mass from consumers</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#DistributionSystem" title="https://w3id.org/fso#DistributionSystem">Distribution system</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+         <dt>is in range of</dt>
+         <dd>
+            <a href="#hasReturnSystem" title="https://w3id.org/fso#hasReturnSystem">has return system</a>
+            <sup class="type-op" title="object property">op</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="Segment">
+      <h3>Segment<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#Segment</p>
+      <div class="comment">
+         <span class="markdown">A component used to enable the passage of material or energy. For example, pipes and ducts.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="StorageDevice">
+      <h3>Storage device<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#StorageDevice</p>
+      <div class="comment">
+         <span class="markdown">A device used to store mass or energy. For example, a water tank.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="SupplySystem">
+      <h3>Supply system<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#SupplySystem</p>
+      <div class="comment">
+         <span class="markdown">A system that supplies energy and/or mass to consumers</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#DistributionSystem" title="https://w3id.org/fso#DistributionSystem">Distribution system</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+         <dt>is in range of</dt>
+         <dd>
+            <a href="#hasSupplySystem" title="https://w3id.org/fso#hasSupplySystem">has supply system</a>
+            <sup class="type-op" title="object property">op</sup>
+         </dd>
       </dl>
    </div>
    <div class="entity" id="System">
@@ -323,15 +610,56 @@ This section provides details for each class and property defined by The Fluid S
          <span class="markdown">A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties.</span>
       </div>
       <dl class="description">
-         <dt>has super-classes</dt>
+         <dt>has sub-classes</dt>
          <dd>
-            <span class="dotted" title="https://w3id.org/fso#Element">element</span>
+            <a href="#DistributionSystem" title="https://w3id.org/fso#DistributionSystem">Distribution system</a>
             <sup class="type-c" title="class">c</sup>
          </dd>
          <dt>is in domain of</dt>
          <dd>
-            <a href="#hasComponent" title="https://w3id.org/fso#hasComponent">has component</a>
+            <a href="#hasSubSystem" title="https://w3id.org/fso#hasSubSystem">has subsystem</a>
             <sup class="type-op" title="object property">op</sup>
+         </dd>
+         <dt>is in range of</dt>
+         <dd>
+            <a href="#hasSubSystem" title="https://w3id.org/fso#hasSubSystem">has subsystem</a>
+            <sup class="type-op" title="object property">op</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="Terminal">
+      <h3>Terminal<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#Terminal</p>
+      <div class="comment">
+         <span class="markdown">A component used to allow material flow out of a distribution system. For example, faucets and air vents.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
+         </dd>
+      </dl>
+   </div>
+   <div class="entity" id="TreatmentDevice">
+      <h3>Treatment device<sup class="type-c" title="class">c</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#TreatmentDevice</p>
+      <div class="comment">
+         <span class="markdown">A device used to change the properties of material flowing through it. For example, filters.</span>
+      </div>
+      <dl class="description">
+         <dt>has super-classes</dt>
+         <dd>
+            <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+            <sup class="type-c" title="class">c</sup>
          </dd>
       </dl>
    </div>
@@ -339,7 +667,10 @@ This section provides details for each class and property defined by The Fluid S
    <h3 id="properties" class="list">Object Properties</h3>
    <ul class="hlist">
       <li>
-         <a href="#fedBy" title="https://w3id.org/fso#fedBy">fed by</a>
+         <a href="#exchangesFluidWith" title="https://w3id.org/fso#exchangesFluidWith">exchanges fluid with</a>
+      </li>
+      <li>
+         <a href="#exchangesHeatWith" title="https://w3id.org/fso#exchangesHeatWith">exchanges heat with</a>
       </li>
       <li>
          <a href="#feeds" title="https://w3id.org/fso#feeds">
@@ -349,25 +680,97 @@ This section provides details for each class and property defined by The Fluid S
       <li>
          <a href="#hasComponent" title="https://w3id.org/fso#hasComponent">has component</a>
       </li>
+      <li>
+         <a href="#hasDensity" title="https://w3id.org/fso#hasDensity">has density</a>
+      </li>
+      <li>
+         <a href="#hasFluid" title="https://w3id.org/fso#hasFluid">has fluid</a>
+      </li>
+      <li>
+         <a href="#hasHeatCapacity" title="https://w3id.org/fso#hasHeatCapacity">has heat capacity</a>
+      </li>
+      <li>
+         <a href="#hasMassFlow" title="https://w3id.org/fso#hasMassFlow">has mass flow</a>
+      </li>
+      <li>
+         <a href="#hasPowerOutput" title="https://w3id.org/fso#hasPowerOutput">
+            <span>has power output</span>
+         </a>
+      </li>
+      <li>
+         <a href="#hasProperty" title="https://w3id.org/fso#hasProperty">has property</a>
+      </li>
+      <li>
+         <a href="#hasReturnSystem" title="https://w3id.org/fso#hasReturnSystem">has return system</a>
+      </li>
+      <li>
+         <a href="#hasReturnTemperature" title="https://w3id.org/fso#hasReturnTemperature">has return temperature</a>
+      </li>
+      <li>
+         <a href="#hasSubSystem" title="https://w3id.org/fso#hasSubSystem">has subsystem</a>
+      </li>
+      <li>
+         <a href="#hasSupplySystem" title="https://w3id.org/fso#hasSupplySystem">has supply system</a>
+      </li>
+      <li>
+         <a href="#hasSupplyTemperature" title="https://w3id.org/fso#hasSupplyTemperature">has supply temperature</a>
+      </li>
+      <li>
+         <a href="#hasTemperature" title="https://w3id.org/fso#hasTemperature">has temperature</a>
+      </li>
+      <li>
+         <a href="#isMadeOfMaterial" title="https://w3id.org/fso#isMadeOfMaterial">is made of material</a>
+      </li>
+      <li>
+         <a href="#returnsFluidTo" title="https://w3id.org/fso#returnsFluidTo">returns fluid to</a>
+      </li>
+      <li>
+         <a href="#suppliesFluidTo" title="https://w3id.org/fso#suppliesFluidTo">supplies fluid to</a>
+      </li>
    </ul>
-   <div class="entity" id="fedBy">
-      <h3>fed by<sup class="type-op" title="object property">op</sup>
+   <div class="entity" id="exchangesFluidWith">
+      <h3>exchanges fluid with<sup class="type-op" title="object property">op</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
          </span>
       </h3>
       <p>
-         <strong>IRI:</strong> https://w3id.org/fso#fedBy</p>
+         <strong>IRI:</strong> https://w3id.org/fso#exchangesFluidWith</p>
       <div class="comment">
-         <span class="markdown"/>
+         <span class="markdown">Relation between two things which have a fluid exchange connection</span>
       </div>
       <div class="description">
          <p>
-            <strong>has characteristics:</strong> transitive</p>
+            <strong>has characteristics:</strong> symmetric</p>
          <dl>
-            <dt>is inverse of</dt>
+            <dt>has super-properties</dt>
+            <dd>
+               <span class="dotted" title="http://www.w3.org/2002/07/owl#topObjectProperty">top object property</span>
+            </dd>
+            <dt>has sub-properties</dt>
             <dd>
                <a href="#feeds" title="https://w3id.org/fso#feeds">feeds</a>
                <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="exchangesHeatWith">
+      <h3>exchanges heat with<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#exchangesHeatWith</p>
+      <div class="comment">
+         <span class="markdown">Relation between two things which have a heat exchange connection</span>
+      </div>
+      <div class="description">
+         <p>
+            <strong>has characteristics:</strong> symmetric</p>
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <span class="dotted" title="http://www.w3.org/2002/07/owl#topObjectProperty">top object property</span>
             </dd>
          </dl>
       </div>
@@ -380,16 +783,18 @@ This section provides details for each class and property defined by The Fluid S
       <p>
          <strong>IRI:</strong> https://w3id.org/fso#feeds</p>
       <div class="description">
-         <p>
-            <strong>has characteristics:</strong> transitive</p>
          <dl>
-            <dt>is inverse of</dt>
+            <dt>has super-properties</dt>
             <dd>
-               <a href="#fedBy" title="https://w3id.org/fso#fedBy">fed by</a>
+               <a href="#exchangesFluidWith" title="https://w3id.org/fso#exchangesFluidWith">exchanges fluid with</a>
                <sup class="type-op" title="object property">op</sup>
             </dd>
-            <dt>is also defined as</dt>
-            <dd>class</dd>
+            <dt>has sub-properties</dt>
+            <dd>
+               <a href="#returnsFluidTo" title="https://w3id.org/fso#returnsFluidTo">returns fluid to</a>
+               <sup class="type-op" title="object property">op</sup>, <a href="#suppliesFluidTo" title="https://w3id.org/fso#suppliesFluidTo">supplies fluid to</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
          </dl>
       </div>
    </div>
@@ -401,19 +806,374 @@ This section provides details for each class and property defined by The Fluid S
       <p>
          <strong>IRI:</strong> https://w3id.org/fso#hasComponent</p>
       <div class="comment">
-         <span class="markdown"/>
+         <span class="markdown">Relates a system to a component it contains</span>
       </div>
       <div class="description">
          <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <span class="dotted" title="http://www.w3.org/2002/07/owl#topObjectProperty">top object property</span>
+            </dd>
+            <dt>has range</dt>
+            <dd>
+               <a href="#Component" title="https://w3id.org/fso#Component">Component</a>
+               <sup class="type-c" title="class">c</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasDensity">
+      <h3>has density<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasDensity</p>
+      <div class="comment">
+         <span class="markdown">A relation between a system and a its density</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasProperty" title="https://w3id.org/fso#hasProperty">has property</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasFluid">
+      <h3>has fluid<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasFluid</p>
+      <div class="comment">
+         <span class="markdown">Relates a system to the fluid it contains</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <span class="dotted" title="http://www.w3.org/2002/07/owl#topObjectProperty">top object property</span>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasHeatCapacity">
+      <h3>has heat capacity<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasHeatCapacity</p>
+      <div class="comment">
+         <span class="markdown">A relation between a thing and its heat capacity</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasProperty" title="https://w3id.org/fso#hasProperty">has property</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasMassFlow">
+      <h3>has mass flow<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasMassFlow</p>
+      <div class="comment">
+         <span class="markdown">Relation between a thing and its mass flow rate</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasProperty" title="https://w3id.org/fso#hasProperty">has property</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasPowerOutput">
+      <h3>has power output<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasPowerOutput</p>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasProperty" title="https://w3id.org/fso#hasProperty">has property</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasProperty">
+      <h3>has property<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasProperty</p>
+      <div class="comment">
+         <span class="markdown">Relation between a thing and a property intrinsic to it</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <span class="dotted" title="http://www.w3.org/2002/07/owl#topObjectProperty">top object property</span>
+            </dd>
+            <dt>has sub-properties</dt>
+            <dd>
+               <a href="#hasDensity" title="https://w3id.org/fso#hasDensity">has density</a>
+               <sup class="type-op" title="object property">op</sup>, <a href="#hasHeatCapacity" title="https://w3id.org/fso#hasHeatCapacity">has heat capacity</a>
+               <sup class="type-op" title="object property">op</sup>, <a href="#hasMassFlow" title="https://w3id.org/fso#hasMassFlow">has mass flow</a>
+               <sup class="type-op" title="object property">op</sup>, <a href="#hasPowerOutput" title="https://w3id.org/fso#hasPowerOutput">has power output</a>
+               <sup class="type-op" title="object property">op</sup>, <a href="#hasTemperature" title="https://w3id.org/fso#hasTemperature">has temperature</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasReturnSystem">
+      <h3>has return system<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasReturnSystem</p>
+      <div class="comment">
+         <span class="markdown">Relation between a system and its return system</span>
+      </div>
+      <div class="description">
+         <p>
+            <strong>has characteristics:</strong> asymmetric</p>
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasSubSystem" title="https://w3id.org/fso#hasSubSystem">has subsystem</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+            <dt>has range</dt>
+            <dd>
+               <a href="#ReturnSystem" title="https://w3id.org/fso#ReturnSystem">Return system</a>
+               <sup class="type-c" title="class">c</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasReturnTemperature">
+      <h3>has return temperature<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasReturnTemperature</p>
+      <div class="comment">
+         <span class="markdown">Relation between a system and its return temperature</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasTemperature" title="https://w3id.org/fso#hasTemperature">has temperature</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+            <dt>has sub-property chains</dt>
+            <dd>
+               <a href="#hasReturnSystem" title="https://w3id.org/fso#hasReturnSystem">has return system</a>
+               <sup class="type-op" title="object property">op</sup> 
+               <span class="logic">o</span> 
+               <a href="#hasTemperature" title="https://w3id.org/fso#hasTemperature">has temperature</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasSubSystem">
+      <h3>has subsystem<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasSubSystem</p>
+      <div class="comment">
+         <span class="markdown">Relation between a system and its subsystem</span>
+      </div>
+      <div class="description">
+         <p>
+            <strong>has characteristics:</strong> asymmetric</p>
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <span class="dotted" title="http://www.w3.org/2002/07/owl#topObjectProperty">top object property</span>
+            </dd>
+            <dt>has sub-properties</dt>
+            <dd>
+               <a href="#hasReturnSystem" title="https://w3id.org/fso#hasReturnSystem">has return system</a>
+               <sup class="type-op" title="object property">op</sup>, <a href="#hasSupplySystem" title="https://w3id.org/fso#hasSupplySystem">has supply system</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
             <dt>has domain</dt>
             <dd>
                <a href="#System" title="https://w3id.org/fso#System">System</a>
                <sup class="type-c" title="class">c</sup>
             </dd>
-            <dt>domain includes</dt>
+            <dt>has range</dt>
             <dd>
-               <a href="#HeatExchanger" title="https://w3id.org/fso#HeatExchanger">Heat Exchanger</a>
+               <a href="#System" title="https://w3id.org/fso#System">System</a>
                <sup class="type-c" title="class">c</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasSupplySystem">
+      <h3>has supply system<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasSupplySystem</p>
+      <div class="comment">
+         <span class="markdown">Relation between a system and its supply system</span>
+      </div>
+      <div class="description">
+         <p>
+            <strong>has characteristics:</strong> asymmetric</p>
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasSubSystem" title="https://w3id.org/fso#hasSubSystem">has subsystem</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+            <dt>has range</dt>
+            <dd>
+               <a href="#SupplySystem" title="https://w3id.org/fso#SupplySystem">Supply system</a>
+               <sup class="type-c" title="class">c</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasSupplyTemperature">
+      <h3>has supply temperature<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasSupplyTemperature</p>
+      <div class="comment">
+         <span class="markdown">Relation between a system and its supply temperature</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasTemperature" title="https://w3id.org/fso#hasTemperature">has temperature</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+            <dt>has sub-property chains</dt>
+            <dd>
+               <a href="#hasSupplySystem" title="https://w3id.org/fso#hasSupplySystem">has supply system</a>
+               <sup class="type-op" title="object property">op</sup> 
+               <span class="logic">o</span> 
+               <a href="#hasTemperature" title="https://w3id.org/fso#hasTemperature">has temperature</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="hasTemperature">
+      <h3>has temperature<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#hasTemperature</p>
+      <div class="comment">
+         <span class="markdown">Relation between a thing and its temperature</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#hasProperty" title="https://w3id.org/fso#hasProperty">has property</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+            <dt>has sub-properties</dt>
+            <dd>
+               <a href="#hasReturnTemperature" title="https://w3id.org/fso#hasReturnTemperature">has return temperature</a>
+               <sup class="type-op" title="object property">op</sup>, <a href="#hasSupplyTemperature" title="https://w3id.org/fso#hasSupplyTemperature">has supply temperature</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="isMadeOfMaterial">
+      <h3>is made of material<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#isMadeOfMaterial</p>
+      <div class="comment">
+         <span class="markdown">Relation between a thing and the material it is made of</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <span class="dotted" title="http://www.w3.org/2002/07/owl#topObjectProperty">top object property</span>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="returnsFluidTo">
+      <h3>returns fluid to<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#returnsFluidTo</p>
+      <div class="comment">
+         <span class="markdown">Relation of a component that supplies fluid to another component</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#feeds" title="https://w3id.org/fso#feeds">feeds</a>
+               <sup class="type-op" title="object property">op</sup>
+            </dd>
+         </dl>
+      </div>
+   </div>
+   <div class="entity" id="suppliesFluidTo">
+      <h3>supplies fluid to<sup class="type-op" title="object property">op</sup>
+         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#objectproperties">Object Property ToC</a>
+         </span>
+      </h3>
+      <p>
+         <strong>IRI:</strong> https://w3id.org/fso#suppliesFluidTo</p>
+      <div class="comment">
+         <span class="markdown">Relation of a component that returns fluid to another component</span>
+      </div>
+      <div class="description">
+         <dl>
+            <dt>has super-properties</dt>
+            <dd>
+               <a href="#feeds" title="https://w3id.org/fso#feeds">feeds</a>
+               <sup class="type-op" title="object property">op</sup>
             </dd>
          </dl>
       </div>
@@ -434,11 +1194,6 @@ This section provides details for each class and property defined by The Fluid S
       <li>
          <a href="#http://purl.org/dc/terms/description" title="http://purl.org/dc/terms/description">
             <span>description</span>
-         </a>
-      </li>
-      <li>
-         <a href="#http://schema.org/domainIncludes" title="http://schema.org/domainIncludes">
-            <span>domain includes</span>
          </a>
       </li>
       <li>
@@ -465,17 +1220,6 @@ This section provides details for each class and property defined by The Fluid S
       <li>
          <a href="#http://purl.org/vocab/vann/preferredNamespaceUri" title="http://purl.org/vocab/vann/preferredNamespaceUri">
             <span>preferred namespace uri</span>
-         </a>
-      </li>
-      <li>
-         <a href="#http://schema.org/rangeIncludes" title="http://schema.org/rangeIncludes">
-            <span>range includes</span>
-         </a>
-      </li>
-      <li>
-         <a href="#http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"
-            title="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status">
-            <span>term status</span>
          </a>
       </li>
       <li>
@@ -507,14 +1251,6 @@ This section provides details for each class and property defined by The Fluid S
       </h3>
       <p>
          <strong>IRI:</strong> http://purl.org/dc/terms/description</p>
-   </div>
-   <div class="entity" id="http://schema.org/domainIncludes">
-      <h3>domain includes<sup class="type-ap" title="annotation property">ap</sup>
-         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#annotationproperties">Annotation Property ToC</a>
-         </span>
-      </h3>
-      <p>
-         <strong>IRI:</strong> http://schema.org/domainIncludes</p>
    </div>
    <div class="entity" id="http://purl.org/dc/terms/issued">
       <h3>issued<sup class="type-ap" title="annotation property">ap</sup>
@@ -555,22 +1291,6 @@ This section provides details for each class and property defined by The Fluid S
       </h3>
       <p>
          <strong>IRI:</strong> http://purl.org/vocab/vann/preferredNamespaceUri</p>
-   </div>
-   <div class="entity" id="http://schema.org/rangeIncludes">
-      <h3>range includes<sup class="type-ap" title="annotation property">ap</sup>
-         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#annotationproperties">Annotation Property ToC</a>
-         </span>
-      </h3>
-      <p>
-         <strong>IRI:</strong> http://schema.org/rangeIncludes</p>
-   </div>
-   <div class="entity" id="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status">
-      <h3>term status<sup class="type-ap" title="annotation property">ap</sup>
-         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#annotationproperties">Annotation Property ToC</a>
-         </span>
-      </h3>
-      <p>
-         <strong>IRI:</strong> http://www.w3.org/2003/06/sw-vocab-status/ns#term_status</p>
    </div>
    <div class="entity" id="http://purl.org/dc/terms/title">
       <h3>title<sup class="type-ap" title="annotation property">ap</sup>

--- a/docs/ontology.json
+++ b/docs/ontology.json
@@ -29,21 +29,6 @@
   "@id" : "http://purl.org/vocommons/voaf#Vocabulary",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ]
 }, {
-  "@id" : "http://schema.org/domainIncludes",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AnnotationProperty" ]
-}, {
-  "@id" : "http://schema.org/rangeIncludes",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AnnotationProperty" ]
-}, {
-  "@id" : "http://www.w3.org/2003/06/sw-vocab-status/ns#term_status",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AnnotationProperty" ]
-}, {
-  "@id" : "http://xmlns.com/foaf/0.1/Person",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ]
-}, {
-  "@id" : "http://xmlns.com/foaf/0.1/name",
-  "@type" : [ "http://www.w3.org/2002/07/owl#DatatypeProperty" ]
-}, {
   "@id" : "https://w3id.org/fso#",
   "@type" : [ "http://www.w3.org/2002/07/owl#Ontology", "http://www.w3.org/2002/07/owl#NamedIndividual", "http://purl.org/vocommons/voaf#Vocabulary" ],
   "http://purl.org/dc/terms/contributor" : [ {
@@ -93,27 +78,177 @@
     "@value" : "0.0.1"
   } ]
 }, {
-  "@id" : "https://w3id.org/fso#Element",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ]
-}, {
-  "@id" : "https://w3id.org/fso#HeatExchanger",
+  "@id" : "https://w3id.org/fso#Component",
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "A heat exchanger is a device designed to transfer energy from one medium to another. Examples of heat exchangers include radiators, heating coils, water/water heat exchangers and mixing plants."
-  }, {
-    "@language" : "da",
-    "@value" : "En varmeveksler er en komponent designet til at overføre energi fra et medie til et andet. Eksempler på varmevekslere omfatter radiatorer, varmeflader, vand/vand varmevekslere og blandeanlæg."
+    "@value" : "A component contained by a fso:System"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
-    "@value" : "Heat Exchanger"
-  }, {
-    "@language" : "da",
-    "@value" : "Varmeveksler"
+    "@value" : "Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#DistributionSystem",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A system that distributes energy and/or mass"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Distribution system"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
-    "@id" : "https://w3id.org/fso#Element"
+    "@id" : "https://w3id.org/fso#System"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#EnergyConversionDevice",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A device that is used to convert energy from one form to another, or move it from one system to another. Potential examples include motors and heat exhangers."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Energy conversion device"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#Fitting",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A component used to connect segments to each other, or to other components. For example, a junction in a pipe system."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Fitting"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#FlowController",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A device that has the potential to control the flow in a network. For example, valves and dampers."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Flow controller"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#FlowMovingDevice",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A device used to induce movement in a network. For example, pumps and fans."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Flow moving device"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#Fluid",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A liquid or gaseous substance, for example water or some mixture"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Fluid"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#Material",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A substance"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Material"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#MonitoringDevice",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Fluid monitoring device"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#ReturnSystem",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A system that returns energy and/or mass from consumers"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Return system"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#DistributionSystem"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#Segment",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A component used to enable the passage of material or energy. For example, pipes and ducts."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Segment"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#StorageDevice",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A device used to store mass or energy. For example, a water tank."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Storage device"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#SupplySystem",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A system that supplies energy and/or mass to consumers"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Supply system"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#DistributionSystem"
   } ]
 }, {
   "@id" : "https://w3id.org/fso#System",
@@ -121,118 +256,316 @@
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
     "@value" : "A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties."
-  }, {
-    "@language" : "da",
-    "@value" : "Et system definerer egenskaber der er gældende for alle komponenter i systemet og fungerer dermed som en grupperingsmekanisme. Typiske systemegenskaber omfatter fluidegenskaber som fluidtype, temperatur og termiske egenskaber."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "da",
-    "@value" : "System"
-  }, {
     "@language" : "en",
     "@value" : "System"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
-    "@id" : "https://w3id.org/fso#Element"
   } ]
 }, {
-  "@id" : "https://w3id.org/fso#fedBy",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#TransitiveProperty" ],
+  "@id" : "https://w3id.org/fso#Terminal",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "da",
-    "@value" : ""
-  }, {
     "@language" : "en",
-    "@value" : ""
+    "@value" : "A component used to allow material flow out of a distribution system. For example, faucets and air vents."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
-    "@value" : "fed by"
-  }, {
-    "@language" : "da",
-    "@value" : "fødes af"
+    "@value" : "Terminal"
   } ],
-  "http://www.w3.org/2002/07/owl#inverseOf" : [ {
-    "@id" : "https://w3id.org/fso#feeds"
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#TreatmentDevice",
+  "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A device used to change the properties of material flowing through it. For example, filters."
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "Treatment device"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#exchangesFluidWith",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#SymmetricProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between two things which have a fluid exchange connection"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "exchanges fluid with"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#exchangesHeatWith",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#SymmetricProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between two things which have a heat exchange connection"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "exchanges heat with"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "http://www.w3.org/2002/07/owl#topObjectProperty"
   } ]
 }, {
   "@id" : "https://w3id.org/fso#feeds",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#TransitiveProperty", "http://www.w3.org/2002/07/owl#Class" ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "da",
-    "@value" : ""
-  }, {
-    "@language" : "en",
-    "@value" : ""
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "feeds"
-  }, {
-    "@language" : "da",
-    "@value" : "føder"
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#exchangesFluidWith"
   } ]
 }, {
   "@id" : "https://w3id.org/fso#hasComponent",
   "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
-  "http://schema.org/domainIncludes" : [ {
-    "@id" : "https://w3id.org/fso#HeatExchanger"
-  } ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "da",
-    "@value" : ""
-  }, {
     "@language" : "en",
-    "@value" : ""
+    "@value" : "Relates a system to a component it contains"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has component"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "https://w3id.org/fso#Component"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasDensity",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A relation between a system and a its density"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has density"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasFluid",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relates a system to the fluid it contains"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has fluid"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasHeatCapacity",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "A relation between a thing and its heat capacity"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has heat capacity"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasMassFlow",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a thing and its mass flow rate"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has mass flow"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasPowerOutput",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasProperty",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a thing and a property intrinsic to it"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has property"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasReturnSystem",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#AsymmetricProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a system and its return system"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has return system"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "https://w3id.org/fso#ReturnSystem"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasSubSystem"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasReturnTemperature",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a system and its return temperature"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has return temperature"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasTemperature"
+  } ],
+  "http://www.w3.org/2002/07/owl#propertyChainAxiom" : [ {
+    "@list" : [ {
+      "@id" : "https://w3id.org/fso#hasReturnSystem"
+    }, {
+      "@id" : "https://w3id.org/fso#hasTemperature"
+    } ]
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasSubSystem",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#AsymmetricProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a system and its subsystem"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#domain" : [ {
     "@id" : "https://w3id.org/fso#System"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "da",
-    "@value" : "har komponent"
-  }, {
     "@language" : "en",
-    "@value" : "has component"
+    "@value" : "has subsystem"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "https://w3id.org/fso#System"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "http://www.w3.org/2002/07/owl#topObjectProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasSupplySystem",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#AsymmetricProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a system and its supply system"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has supply system"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
+    "@id" : "https://w3id.org/fso#SupplySystem"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasSubSystem"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasSupplyTemperature",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a system and its supply temperature"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has supply temperature"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasTemperature"
+  } ],
+  "http://www.w3.org/2002/07/owl#propertyChainAxiom" : [ {
+    "@list" : [ {
+      "@id" : "https://w3id.org/fso#hasSupplySystem"
+    }, {
+      "@id" : "https://w3id.org/fso#hasTemperature"
+    } ]
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#hasTemperature",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a thing and its temperature"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "has temperature"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "https://w3id.org/fso#hasProperty"
+  } ]
+}, {
+  "@id" : "https://w3id.org/fso#isMadeOfMaterial",
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
+  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
+    "@language" : "en",
+    "@value" : "Relation between a thing and the material it is made of"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
+    "@language" : "en",
+    "@value" : "is made of material"
+  } ],
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
+    "@id" : "http://www.w3.org/2002/07/owl#topObjectProperty"
   } ]
 }, {
   "@id" : "https://w3id.org/fso#returnsFluidTo",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#Class" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "da",
-    "@value" : ""
-  }, {
     "@language" : "en",
-    "@value" : ""
+    "@value" : "Relation of a component that supplies fluid to another component"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "da",
-    "@value" : "returnerer fluid til"
-  }, {
     "@language" : "en",
     "@value" : "returns fluid to"
   } ],
-  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
     "@id" : "https://w3id.org/fso#feeds"
   } ]
 }, {
   "@id" : "https://w3id.org/fso#suppliesFluidTo",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty", "http://www.w3.org/2002/07/owl#Class" ],
+  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "da",
-    "@value" : ""
-  }, {
     "@language" : "en",
-    "@value" : ""
+    "@value" : "Relation of a component that returns fluid to another component"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "da",
-    "@value" : "forsyner fluid til"
-  }, {
     "@language" : "en",
     "@value" : "supplies fluid to"
   } ],
-  "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
+  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
     "@id" : "https://w3id.org/fso#feeds"
   } ]
 } ]

--- a/docs/ontology.nt
+++ b/docs/ontology.nt
@@ -50,15 +50,6 @@
 # http://purl.org/vocab/vann/preferredNamespaceUri
 <http://purl.org/vocab/vann/preferredNamespaceUri> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 # 
-# http://schema.org/domainIncludes
-<http://schema.org/domainIncludes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-# 
-# http://schema.org/rangeIncludes
-<http://schema.org/rangeIncludes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-# 
-# http://www.w3.org/2003/06/sw-vocab-status/ns#term_status
-<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-# 
 # 
 # 
 # #################################################################
@@ -68,45 +59,139 @@
 # #################################################################
 # 
 # 
-# https://w3id.org/fso#fedBy
-<https://w3id.org/fso#fedBy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
-<https://w3id.org/fso#fedBy> <http://www.w3.org/2002/07/owl#inverseOf> <https://w3id.org/fso#feeds> .
-<https://w3id.org/fso#fedBy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#TransitiveProperty> .
-<https://w3id.org/fso#fedBy> <http://www.w3.org/2000/01/rdf-schema#comment> ""@da .
-<https://w3id.org/fso#fedBy> <http://www.w3.org/2000/01/rdf-schema#comment> ""@en .
-<https://w3id.org/fso#fedBy> <http://www.w3.org/2000/01/rdf-schema#label> "fed by"@en .
-<https://w3id.org/fso#fedBy> <http://www.w3.org/2000/01/rdf-schema#label> "fødes af"@da .
+# https://w3id.org/fso#exchangesFluidWith
+<https://w3id.org/fso#exchangesFluidWith> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#exchangesFluidWith> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/2002/07/owl#topObjectProperty> .
+<https://w3id.org/fso#exchangesFluidWith> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#SymmetricProperty> .
+<https://w3id.org/fso#exchangesFluidWith> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between two things which have a fluid exchange connection"@en .
+<https://w3id.org/fso#exchangesFluidWith> <http://www.w3.org/2000/01/rdf-schema#label> "exchanges fluid with"@en .
+# 
+# https://w3id.org/fso#exchangesHeatWith
+<https://w3id.org/fso#exchangesHeatWith> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#exchangesHeatWith> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/2002/07/owl#topObjectProperty> .
+<https://w3id.org/fso#exchangesHeatWith> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#SymmetricProperty> .
+<https://w3id.org/fso#exchangesHeatWith> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between two things which have a heat exchange connection"@en .
+<https://w3id.org/fso#exchangesHeatWith> <http://www.w3.org/2000/01/rdf-schema#label> "exchanges heat with"@en .
 # 
 # https://w3id.org/fso#feeds
 <https://w3id.org/fso#feeds> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
-<https://w3id.org/fso#feeds> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#TransitiveProperty> .
+<https://w3id.org/fso#feeds> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#exchangesFluidWith> .
 # 
 # https://w3id.org/fso#hasComponent
 <https://w3id.org/fso#hasComponent> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
-<https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#domain> <https://w3id.org/fso#System> .
-<https://w3id.org/fso#hasComponent> <http://schema.org/domainIncludes> <https://w3id.org/fso#HeatExchanger> .
-<https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#comment> ""@da .
-<https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#comment> ""@en .
-<https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#label> "har komponent"@da .
+<https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/2002/07/owl#topObjectProperty> .
+<https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#range> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#comment> "Relates a system to a component it contains"@en .
 <https://w3id.org/fso#hasComponent> <http://www.w3.org/2000/01/rdf-schema#label> "has component"@en .
+# 
+# https://w3id.org/fso#hasDensity
+<https://w3id.org/fso#hasDensity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasDensity> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasProperty> .
+<https://w3id.org/fso#hasDensity> <http://www.w3.org/2000/01/rdf-schema#comment> "A relation between a system and a its density"@en .
+<https://w3id.org/fso#hasDensity> <http://www.w3.org/2000/01/rdf-schema#label> "has density"@en .
+# 
+# https://w3id.org/fso#hasFluid
+<https://w3id.org/fso#hasFluid> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasFluid> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/2002/07/owl#topObjectProperty> .
+<https://w3id.org/fso#hasFluid> <http://www.w3.org/2000/01/rdf-schema#comment> "Relates a system to the fluid it contains"@en .
+<https://w3id.org/fso#hasFluid> <http://www.w3.org/2000/01/rdf-schema#label> "has fluid"@en .
+# 
+# https://w3id.org/fso#hasHeatCapacity
+<https://w3id.org/fso#hasHeatCapacity> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasHeatCapacity> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasProperty> .
+<https://w3id.org/fso#hasHeatCapacity> <http://www.w3.org/2000/01/rdf-schema#comment> "A relation between a thing and its heat capacity"@en .
+<https://w3id.org/fso#hasHeatCapacity> <http://www.w3.org/2000/01/rdf-schema#label> "has heat capacity"@en .
+# 
+# https://w3id.org/fso#hasMassFlow
+<https://w3id.org/fso#hasMassFlow> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasMassFlow> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasProperty> .
+<https://w3id.org/fso#hasMassFlow> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a thing and its mass flow rate"@en .
+<https://w3id.org/fso#hasMassFlow> <http://www.w3.org/2000/01/rdf-schema#label> "has mass flow"@en .
+# 
+# https://w3id.org/fso#hasPowerOutput
+<https://w3id.org/fso#hasPowerOutput> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasPowerOutput> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasProperty> .
+# 
+# https://w3id.org/fso#hasProperty
+<https://w3id.org/fso#hasProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasProperty> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/2002/07/owl#topObjectProperty> .
+<https://w3id.org/fso#hasProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a thing and a property intrinsic to it"@en .
+<https://w3id.org/fso#hasProperty> <http://www.w3.org/2000/01/rdf-schema#label> "has property"@en .
+# 
+# https://w3id.org/fso#hasReturnSystem
+<https://w3id.org/fso#hasReturnSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasReturnSystem> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasSubSystem> .
+<https://w3id.org/fso#hasReturnSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#AsymmetricProperty> .
+<https://w3id.org/fso#hasReturnSystem> <http://www.w3.org/2000/01/rdf-schema#range> <https://w3id.org/fso#ReturnSystem> .
+<https://w3id.org/fso#hasReturnSystem> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a system and its return system"@en .
+<https://w3id.org/fso#hasReturnSystem> <http://www.w3.org/2000/01/rdf-schema#label> "has return system"@en .
+# 
+# https://w3id.org/fso#hasReturnTemperature
+<https://w3id.org/fso#hasReturnTemperature> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasReturnTemperature> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasTemperature> .
+<https://w3id.org/fso#hasReturnTemperature> <http://www.w3.org/2002/07/owl#propertyChainAxiom> _:genid2 .
+_:genid2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#List> .
+_:genid2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3id.org/fso#hasReturnSystem> .
+_:genid2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:genid1 .
+_:genid1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#List> .
+_:genid1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3id.org/fso#hasTemperature> .
+_:genid1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<https://w3id.org/fso#hasReturnTemperature> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a system and its return temperature"@en .
+<https://w3id.org/fso#hasReturnTemperature> <http://www.w3.org/2000/01/rdf-schema#label> "has return temperature"@en .
+# 
+# https://w3id.org/fso#hasSubSystem
+<https://w3id.org/fso#hasSubSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasSubSystem> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/2002/07/owl#topObjectProperty> .
+<https://w3id.org/fso#hasSubSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#AsymmetricProperty> .
+<https://w3id.org/fso#hasSubSystem> <http://www.w3.org/2000/01/rdf-schema#domain> <https://w3id.org/fso#System> .
+<https://w3id.org/fso#hasSubSystem> <http://www.w3.org/2000/01/rdf-schema#range> <https://w3id.org/fso#System> .
+<https://w3id.org/fso#hasSubSystem> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a system and its subsystem"@en .
+<https://w3id.org/fso#hasSubSystem> <http://www.w3.org/2000/01/rdf-schema#label> "has subsystem"@en .
+# 
+# https://w3id.org/fso#hasSupplySystem
+<https://w3id.org/fso#hasSupplySystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasSupplySystem> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasSubSystem> .
+<https://w3id.org/fso#hasSupplySystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#AsymmetricProperty> .
+<https://w3id.org/fso#hasSupplySystem> <http://www.w3.org/2000/01/rdf-schema#range> <https://w3id.org/fso#SupplySystem> .
+<https://w3id.org/fso#hasSupplySystem> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a system and its supply system"@en .
+<https://w3id.org/fso#hasSupplySystem> <http://www.w3.org/2000/01/rdf-schema#label> "has supply system"@en .
+# 
+# https://w3id.org/fso#hasSupplyTemperature
+<https://w3id.org/fso#hasSupplyTemperature> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasSupplyTemperature> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasTemperature> .
+<https://w3id.org/fso#hasSupplyTemperature> <http://www.w3.org/2002/07/owl#propertyChainAxiom> _:genid4 .
+_:genid4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#List> .
+_:genid4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3id.org/fso#hasSupplySystem> .
+_:genid4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:genid3 .
+_:genid3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#List> .
+_:genid3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3id.org/fso#hasTemperature> .
+_:genid3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<https://w3id.org/fso#hasSupplyTemperature> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a system and its supply temperature"@en .
+<https://w3id.org/fso#hasSupplyTemperature> <http://www.w3.org/2000/01/rdf-schema#label> "has supply temperature"@en .
+# 
+# https://w3id.org/fso#hasTemperature
+<https://w3id.org/fso#hasTemperature> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#hasTemperature> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#hasProperty> .
+<https://w3id.org/fso#hasTemperature> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a thing and its temperature"@en .
+<https://w3id.org/fso#hasTemperature> <http://www.w3.org/2000/01/rdf-schema#label> "has temperature"@en .
+# 
+# https://w3id.org/fso#isMadeOfMaterial
+<https://w3id.org/fso#isMadeOfMaterial> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#isMadeOfMaterial> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/2002/07/owl#topObjectProperty> .
+<https://w3id.org/fso#isMadeOfMaterial> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between a thing and the material it is made of"@en .
+<https://w3id.org/fso#isMadeOfMaterial> <http://www.w3.org/2000/01/rdf-schema#label> "is made of material"@en .
 # 
 # https://w3id.org/fso#returnsFluidTo
 <https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#feeds> .
+<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation of a component that supplies fluid to another component"@en .
+<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#label> "returns fluid to"@en .
 # 
 # https://w3id.org/fso#suppliesFluidTo
 <https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Data properties
-# #
-# #################################################################
-# 
-# 
-# http://xmlns.com/foaf/0.1/name
-<http://xmlns.com/foaf/0.1/name> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#DatatypeProperty> .
+<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <https://w3id.org/fso#feeds> .
+<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#comment> "Relation of a component that returns fluid to another component"@en .
+<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#label> "supplies fluid to"@en .
 # 
 # 
 # 
@@ -120,38 +205,97 @@
 # http://purl.org/vocommons/voaf#Vocabulary
 <http://purl.org/vocommons/voaf#Vocabulary> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 # 
-# http://xmlns.com/foaf/0.1/Person
-<http://xmlns.com/foaf/0.1/Person> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+# https://w3id.org/fso#Component
+<https://w3id.org/fso#Component> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#Component> <http://www.w3.org/2000/01/rdf-schema#comment> "A component contained by a fso:System"@en .
+<https://w3id.org/fso#Component> <http://www.w3.org/2000/01/rdf-schema#label> "Component"@en .
 # 
-# https://w3id.org/fso#Element
-<https://w3id.org/fso#Element> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+# https://w3id.org/fso#DistributionSystem
+<https://w3id.org/fso#DistributionSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#DistributionSystem> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#System> .
+<https://w3id.org/fso#DistributionSystem> <http://www.w3.org/2000/01/rdf-schema#comment> "A system that distributes energy and/or mass"@en .
+<https://w3id.org/fso#DistributionSystem> <http://www.w3.org/2000/01/rdf-schema#label> "Distribution system"@en .
 # 
-# https://w3id.org/fso#HeatExchanger
-<https://w3id.org/fso#HeatExchanger> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
-<https://w3id.org/fso#HeatExchanger> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Element> .
-<https://w3id.org/fso#HeatExchanger> <http://www.w3.org/2000/01/rdf-schema#comment> "A heat exchanger is a device designed to transfer energy from one medium to another. Examples of heat exchangers include radiators, heating coils, water/water heat exchangers and mixing plants."@en .
-<https://w3id.org/fso#HeatExchanger> <http://www.w3.org/2000/01/rdf-schema#comment> "En varmeveksler er en komponent designet til at overføre energi fra et medie til et andet. Eksempler på varmevekslere omfatter radiatorer, varmeflader, vand/vand varmevekslere og blandeanlæg."@da .
-<https://w3id.org/fso#HeatExchanger> <http://www.w3.org/2000/01/rdf-schema#label> "Heat Exchanger"@en .
-<https://w3id.org/fso#HeatExchanger> <http://www.w3.org/2000/01/rdf-schema#label> "Varmeveksler"@da .
+# https://w3id.org/fso#EnergyConversionDevice
+<https://w3id.org/fso#EnergyConversionDevice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#EnergyConversionDevice> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#EnergyConversionDevice> <http://www.w3.org/2000/01/rdf-schema#comment> "A device that is used to convert energy from one form to another, or move it from one system to another. Potential examples include motors and heat exhangers."@en .
+<https://w3id.org/fso#EnergyConversionDevice> <http://www.w3.org/2000/01/rdf-schema#label> "Energy conversion device"@en .
+# 
+# https://w3id.org/fso#Fitting
+<https://w3id.org/fso#Fitting> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#Fitting> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#Fitting> <http://www.w3.org/2000/01/rdf-schema#comment> "A component used to connect segments to each other, or to other components. For example, a junction in a pipe system."@en .
+<https://w3id.org/fso#Fitting> <http://www.w3.org/2000/01/rdf-schema#label> "Fitting"@en .
+# 
+# https://w3id.org/fso#FlowController
+<https://w3id.org/fso#FlowController> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#FlowController> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#FlowController> <http://www.w3.org/2000/01/rdf-schema#comment> "A device that has the potential to control the flow in a network. For example, valves and dampers."@en .
+<https://w3id.org/fso#FlowController> <http://www.w3.org/2000/01/rdf-schema#label> "Flow controller"@en .
+# 
+# https://w3id.org/fso#FlowMovingDevice
+<https://w3id.org/fso#FlowMovingDevice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#FlowMovingDevice> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#FlowMovingDevice> <http://www.w3.org/2000/01/rdf-schema#comment> "A device used to induce movement in a network. For example, pumps and fans."@en .
+<https://w3id.org/fso#FlowMovingDevice> <http://www.w3.org/2000/01/rdf-schema#label> "Flow moving device"@en .
+# 
+# https://w3id.org/fso#Fluid
+<https://w3id.org/fso#Fluid> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#Fluid> <http://www.w3.org/2000/01/rdf-schema#comment> "A liquid or gaseous substance, for example water or some mixture"@en .
+<https://w3id.org/fso#Fluid> <http://www.w3.org/2000/01/rdf-schema#label> "Fluid"@en .
+# 
+# https://w3id.org/fso#Material
+<https://w3id.org/fso#Material> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#Material> <http://www.w3.org/2000/01/rdf-schema#comment> "A substance"@en .
+<https://w3id.org/fso#Material> <http://www.w3.org/2000/01/rdf-schema#label> "Material"@en .
+# 
+# https://w3id.org/fso#MonitoringDevice
+<https://w3id.org/fso#MonitoringDevice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#MonitoringDevice> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#MonitoringDevice> <http://www.w3.org/2000/01/rdf-schema#comment> "A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter."@en .
+<https://w3id.org/fso#MonitoringDevice> <http://www.w3.org/2000/01/rdf-schema#label> "Fluid monitoring device"@en .
+# 
+# https://w3id.org/fso#ReturnSystem
+<https://w3id.org/fso#ReturnSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#ReturnSystem> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#DistributionSystem> .
+<https://w3id.org/fso#ReturnSystem> <http://www.w3.org/2000/01/rdf-schema#comment> "A system that returns energy and/or mass from consumers"@en .
+<https://w3id.org/fso#ReturnSystem> <http://www.w3.org/2000/01/rdf-schema#label> "Return system"@en .
+# 
+# https://w3id.org/fso#Segment
+<https://w3id.org/fso#Segment> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#Segment> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#Segment> <http://www.w3.org/2000/01/rdf-schema#comment> "A component used to enable the passage of material or energy. For example, pipes and ducts."@en .
+<https://w3id.org/fso#Segment> <http://www.w3.org/2000/01/rdf-schema#label> "Segment"@en .
+# 
+# https://w3id.org/fso#StorageDevice
+<https://w3id.org/fso#StorageDevice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#StorageDevice> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#StorageDevice> <http://www.w3.org/2000/01/rdf-schema#comment> "A device used to store mass or energy. For example, a water tank."@en .
+<https://w3id.org/fso#StorageDevice> <http://www.w3.org/2000/01/rdf-schema#label> "Storage device"@en .
+# 
+# https://w3id.org/fso#SupplySystem
+<https://w3id.org/fso#SupplySystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#SupplySystem> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#DistributionSystem> .
+<https://w3id.org/fso#SupplySystem> <http://www.w3.org/2000/01/rdf-schema#comment> "A system that supplies energy and/or mass to consumers"@en .
+<https://w3id.org/fso#SupplySystem> <http://www.w3.org/2000/01/rdf-schema#label> "Supply system"@en .
 # 
 # https://w3id.org/fso#System
 <https://w3id.org/fso#System> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
-<https://w3id.org/fso#System> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Element> .
 <https://w3id.org/fso#System> <http://www.w3.org/2000/01/rdf-schema#comment> "A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties."@en .
-<https://w3id.org/fso#System> <http://www.w3.org/2000/01/rdf-schema#comment> "Et system definerer egenskaber der er gældende for alle komponenter i systemet og fungerer dermed som en grupperingsmekanisme. Typiske systemegenskaber omfatter fluidegenskaber som fluidtype, temperatur og termiske egenskaber."@da .
-<https://w3id.org/fso#System> <http://www.w3.org/2000/01/rdf-schema#label> "System"@da .
 <https://w3id.org/fso#System> <http://www.w3.org/2000/01/rdf-schema#label> "System"@en .
 # 
-# https://w3id.org/fso#feeds
-<https://w3id.org/fso#feeds> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+# https://w3id.org/fso#Terminal
+<https://w3id.org/fso#Terminal> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#Terminal> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#Terminal> <http://www.w3.org/2000/01/rdf-schema#comment> "A component used to allow material flow out of a distribution system. For example, faucets and air vents."@en .
+<https://w3id.org/fso#Terminal> <http://www.w3.org/2000/01/rdf-schema#label> "Terminal"@en .
 # 
-# https://w3id.org/fso#returnsFluidTo
-<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
-<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#feeds> .
-# 
-# https://w3id.org/fso#suppliesFluidTo
-<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
-<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#feeds> .
+# https://w3id.org/fso#TreatmentDevice
+<https://w3id.org/fso#TreatmentDevice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
+<https://w3id.org/fso#TreatmentDevice> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://w3id.org/fso#Component> .
+<https://w3id.org/fso#TreatmentDevice> <http://www.w3.org/2000/01/rdf-schema#comment> "A device used to change the properties of material flowing through it. For example, filters."@en .
+<https://w3id.org/fso#TreatmentDevice> <http://www.w3.org/2000/01/rdf-schema#label> "Treatment device"@en .
 # 
 # 
 # 
@@ -165,29 +309,5 @@
 # https://w3id.org/fso#
 <https://w3id.org/fso#> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <https://w3id.org/fso#> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/vocommons/voaf#Vocabulary> .
-# 
-# 
-# 
-# #################################################################
-# #
-# #    Annotations
-# #
-# #################################################################
-# 
-# 
-<https://w3id.org/fso#feeds> <http://www.w3.org/2000/01/rdf-schema#comment> ""@da .
-<https://w3id.org/fso#feeds> <http://www.w3.org/2000/01/rdf-schema#comment> ""@en .
-<https://w3id.org/fso#feeds> <http://www.w3.org/2000/01/rdf-schema#label> "feeds"@en .
-<https://w3id.org/fso#feeds> <http://www.w3.org/2000/01/rdf-schema#label> "føder"@da .
-# 
-<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#comment> ""@da .
-<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#comment> ""@en .
-<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#label> "returnerer fluid til"@da .
-<https://w3id.org/fso#returnsFluidTo> <http://www.w3.org/2000/01/rdf-schema#label> "returns fluid to"@en .
-# 
-<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#comment> ""@da .
-<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#comment> ""@en .
-<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#label> "forsyner fluid til"@da .
-<https://w3id.org/fso#suppliesFluidTo> <http://www.w3.org/2000/01/rdf-schema#label> "supplies fluid to"@en .
 # 
 # Generated by the OWL API (version 5.1.11) https://github.com/owlcs/owlapi/

--- a/docs/ontology.ttl
+++ b/docs/ontology.ttl
@@ -63,61 +63,153 @@
 <http://purl.org/vocab/vann/preferredNamespaceUri> rdf:type owl:AnnotationProperty .
 
 
-###  http://schema.org/domainIncludes
-<http://schema.org/domainIncludes> rdf:type owl:AnnotationProperty .
-
-
-###  http://schema.org/rangeIncludes
-<http://schema.org/rangeIncludes> rdf:type owl:AnnotationProperty .
-
-
-###  http://www.w3.org/2003/06/sw-vocab-status/ns#term_status
-<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> rdf:type owl:AnnotationProperty .
-
-
 #################################################################
 #    Object Properties
 #################################################################
 
-###  https://w3id.org/fso#fedBy
-:fedBy rdf:type owl:ObjectProperty ;
-       owl:inverseOf :feeds ;
-       rdf:type owl:TransitiveProperty ;
-       rdfs:comment ""@da ,
-                    ""@en ;
-       rdfs:label "fed by"@en ,
-                  "fødes af"@da .
+###  https://w3id.org/fso#exchangesFluidWith
+:exchangesFluidWith rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf owl:topObjectProperty ;
+                    rdf:type owl:SymmetricProperty ;
+                    rdfs:comment "Relation between two things which have a fluid exchange connection"@en ;
+                    rdfs:label "exchanges fluid with"@en .
+
+
+###  https://w3id.org/fso#exchangesHeatWith
+:exchangesHeatWith rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf owl:topObjectProperty ;
+                   rdf:type owl:SymmetricProperty ;
+                   rdfs:comment "Relation between two things which have a heat exchange connection"@en ;
+                   rdfs:label "exchanges heat with"@en .
 
 
 ###  https://w3id.org/fso#feeds
-:feeds rdf:type owl:ObjectProperty ,
-                owl:TransitiveProperty .
+:feeds rdf:type owl:ObjectProperty ;
+       rdfs:subPropertyOf :exchangesFluidWith .
 
 
 ###  https://w3id.org/fso#hasComponent
 :hasComponent rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf owl:topObjectProperty ;
+              rdfs:range :Component ;
+              rdfs:comment "Relates a system to a component it contains"@en ;
+              rdfs:label "has component"@en .
+
+
+###  https://w3id.org/fso#hasDensity
+:hasDensity rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :hasProperty ;
+            rdfs:comment "A relation between a system and a its density"@en ;
+            rdfs:label "has density"@en .
+
+
+###  https://w3id.org/fso#hasFluid
+:hasFluid rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf owl:topObjectProperty ;
+          rdfs:comment "Relates a system to the fluid it contains"@en ;
+          rdfs:label "has fluid"@en .
+
+
+###  https://w3id.org/fso#hasHeatCapacity
+:hasHeatCapacity rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :hasProperty ;
+                 rdfs:comment "A relation between a thing and its heat capacity"@en ;
+                 rdfs:label "has heat capacity"@en .
+
+
+###  https://w3id.org/fso#hasMassFlow
+:hasMassFlow rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf :hasProperty ;
+             rdfs:comment "Relation between a thing and its mass flow rate"@en ;
+             rdfs:label "has mass flow"@en .
+
+
+###  https://w3id.org/fso#hasPowerOutput
+:hasPowerOutput rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :hasProperty .
+
+
+###  https://w3id.org/fso#hasProperty
+:hasProperty rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf owl:topObjectProperty ;
+             rdfs:comment "Relation between a thing and a property intrinsic to it"@en ;
+             rdfs:label "has property"@en .
+
+
+###  https://w3id.org/fso#hasReturnSystem
+:hasReturnSystem rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :hasSubSystem ;
+                 rdf:type owl:AsymmetricProperty ;
+                 rdfs:range :ReturnSystem ;
+                 rdfs:comment "Relation between a system and its return system"@en ;
+                 rdfs:label "has return system"@en .
+
+
+###  https://w3id.org/fso#hasReturnTemperature
+:hasReturnTemperature rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf :hasTemperature ;
+                      owl:propertyChainAxiom ( :hasReturnSystem
+                                               :hasTemperature
+                                             ) ;
+                      rdfs:comment "Relation between a system and its return temperature"@en ;
+                      rdfs:label "has return temperature"@en .
+
+
+###  https://w3id.org/fso#hasSubSystem
+:hasSubSystem rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf owl:topObjectProperty ;
+              rdf:type owl:AsymmetricProperty ;
               rdfs:domain :System ;
-              <http://schema.org/domainIncludes> :HeatExchanger ;
-              rdfs:comment ""@da ,
-                           ""@en ;
-              rdfs:label "har komponent"@da ,
-                         "has component"@en .
+              rdfs:range :System ;
+              rdfs:comment "Relation between a system and its subsystem"@en ;
+              rdfs:label "has subsystem"@en .
+
+
+###  https://w3id.org/fso#hasSupplySystem
+:hasSupplySystem rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :hasSubSystem ;
+                 rdf:type owl:AsymmetricProperty ;
+                 rdfs:range :SupplySystem ;
+                 rdfs:comment "Relation between a system and its supply system"@en ;
+                 rdfs:label "has supply system"@en .
+
+
+###  https://w3id.org/fso#hasSupplyTemperature
+:hasSupplyTemperature rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf :hasTemperature ;
+                      owl:propertyChainAxiom ( :hasSupplySystem
+                                               :hasTemperature
+                                             ) ;
+                      rdfs:comment "Relation between a system and its supply temperature"@en ;
+                      rdfs:label "has supply temperature"@en .
+
+
+###  https://w3id.org/fso#hasTemperature
+:hasTemperature rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :hasProperty ;
+                rdfs:comment "Relation between a thing and its temperature"@en ;
+                rdfs:label "has temperature"@en .
+
+
+###  https://w3id.org/fso#isMadeOfMaterial
+:isMadeOfMaterial rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf owl:topObjectProperty ;
+                  rdfs:comment "Relation between a thing and the material it is made of"@en ;
+                  rdfs:label "is made of material"@en .
 
 
 ###  https://w3id.org/fso#returnsFluidTo
-:returnsFluidTo rdf:type owl:ObjectProperty .
+:returnsFluidTo rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :feeds ;
+                rdfs:comment "Relation of a component that supplies fluid to another component"@en ;
+                rdfs:label "returns fluid to"@en .
 
 
 ###  https://w3id.org/fso#suppliesFluidTo
-:suppliesFluidTo rdf:type owl:ObjectProperty .
-
-
-#################################################################
-#    Data properties
-#################################################################
-
-###  http://xmlns.com/foaf/0.1/name
-<http://xmlns.com/foaf/0.1/name> rdf:type owl:DatatypeProperty .
+:suppliesFluidTo rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :feeds ;
+                 rdfs:comment "Relation of a component that returns fluid to another component"@en ;
+                 rdfs:label "supplies fluid to"@en .
 
 
 #################################################################
@@ -128,44 +220,112 @@
 <http://purl.org/vocommons/voaf#Vocabulary> rdf:type owl:Class .
 
 
-###  http://xmlns.com/foaf/0.1/Person
-<http://xmlns.com/foaf/0.1/Person> rdf:type owl:Class .
+###  https://w3id.org/fso#Component
+:Component rdf:type owl:Class ;
+           rdfs:comment "A component contained by a fso:System"@en ;
+           rdfs:label "Component"@en .
 
 
-###  https://w3id.org/fso#Element
-:Element rdf:type owl:Class .
+###  https://w3id.org/fso#DistributionSystem
+:DistributionSystem rdf:type owl:Class ;
+                    rdfs:subClassOf :System ;
+                    rdfs:comment "A system that distributes energy and/or mass"@en ;
+                    rdfs:label "Distribution system"@en .
 
 
-###  https://w3id.org/fso#HeatExchanger
-:HeatExchanger rdf:type owl:Class ;
-               rdfs:subClassOf :Element ;
-               rdfs:comment "A heat exchanger is a device designed to transfer energy from one medium to another. Examples of heat exchangers include radiators, heating coils, water/water heat exchangers and mixing plants."@en ,
-                            "En varmeveksler er en komponent designet til at overføre energi fra et medie til et andet. Eksempler på varmevekslere omfatter radiatorer, varmeflader, vand/vand varmevekslere og blandeanlæg."@da ;
-               rdfs:label "Heat Exchanger"@en ,
-                          "Varmeveksler"@da .
+###  https://w3id.org/fso#EnergyConversionDevice
+:EnergyConversionDevice rdf:type owl:Class ;
+                        rdfs:subClassOf :Component ;
+                        rdfs:comment "A device that is used to convert energy from one form to another, or move it from one system to another. Potential examples include motors and heat exhangers."@en ;
+                        rdfs:label "Energy conversion device"@en .
+
+
+###  https://w3id.org/fso#Fitting
+:Fitting rdf:type owl:Class ;
+         rdfs:subClassOf :Component ;
+         rdfs:comment "A component used to connect segments to each other, or to other components. For example, a junction in a pipe system."@en ;
+         rdfs:label "Fitting"@en .
+
+
+###  https://w3id.org/fso#FlowController
+:FlowController rdf:type owl:Class ;
+                rdfs:subClassOf :Component ;
+                rdfs:comment "A device that has the potential to control the flow in a network. For example, valves and dampers."@en ;
+                rdfs:label "Flow controller"@en .
+
+
+###  https://w3id.org/fso#FlowMovingDevice
+:FlowMovingDevice rdf:type owl:Class ;
+                  rdfs:subClassOf :Component ;
+                  rdfs:comment "A device used to induce movement in a network. For example, pumps and fans."@en ;
+                  rdfs:label "Flow moving device"@en .
+
+
+###  https://w3id.org/fso#Fluid
+:Fluid rdf:type owl:Class ;
+       rdfs:comment "A liquid or gaseous substance, for example water or some mixture"@en ;
+       rdfs:label "Fluid"@en .
+
+
+###  https://w3id.org/fso#Material
+:Material rdf:type owl:Class ;
+          rdfs:comment "A substance"@en ;
+          rdfs:label "Material"@en .
+
+
+###  https://w3id.org/fso#MonitoringDevice
+:MonitoringDevice rdf:type owl:Class ;
+                  rdfs:subClassOf :Component ;
+                  rdfs:comment "A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter."@en ;
+                  rdfs:label "Fluid monitoring device"@en .
+
+
+###  https://w3id.org/fso#ReturnSystem
+:ReturnSystem rdf:type owl:Class ;
+              rdfs:subClassOf :DistributionSystem ;
+              rdfs:comment "A system that returns energy and/or mass from consumers"@en ;
+              rdfs:label "Return system"@en .
+
+
+###  https://w3id.org/fso#Segment
+:Segment rdf:type owl:Class ;
+         rdfs:subClassOf :Component ;
+         rdfs:comment "A component used to enable the passage of material or energy. For example, pipes and ducts."@en ;
+         rdfs:label "Segment"@en .
+
+
+###  https://w3id.org/fso#StorageDevice
+:StorageDevice rdf:type owl:Class ;
+               rdfs:subClassOf :Component ;
+               rdfs:comment "A device used to store mass or energy. For example, a water tank."@en ;
+               rdfs:label "Storage device"@en .
+
+
+###  https://w3id.org/fso#SupplySystem
+:SupplySystem rdf:type owl:Class ;
+              rdfs:subClassOf :DistributionSystem ;
+              rdfs:comment "A system that supplies energy and/or mass to consumers"@en ;
+              rdfs:label "Supply system"@en .
 
 
 ###  https://w3id.org/fso#System
 :System rdf:type owl:Class ;
-        rdfs:subClassOf :Element ;
-        rdfs:comment "A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties."@en ,
-                     "Et system definerer egenskaber der er gældende for alle komponenter i systemet og fungerer dermed som en grupperingsmekanisme. Typiske systemegenskaber omfatter fluidegenskaber som fluidtype, temperatur og termiske egenskaber."@da ;
-        rdfs:label "System"@da ,
-                   "System"@en .
+        rdfs:comment "A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties."@en ;
+        rdfs:label "System"@en .
 
 
-###  https://w3id.org/fso#feeds
-:feeds rdf:type owl:Class .
+###  https://w3id.org/fso#Terminal
+:Terminal rdf:type owl:Class ;
+          rdfs:subClassOf :Component ;
+          rdfs:comment "A component used to allow material flow out of a distribution system. For example, faucets and air vents."@en ;
+          rdfs:label "Terminal"@en .
 
 
-###  https://w3id.org/fso#returnsFluidTo
-:returnsFluidTo rdf:type owl:Class ;
-                rdfs:subClassOf :feeds .
-
-
-###  https://w3id.org/fso#suppliesFluidTo
-:suppliesFluidTo rdf:type owl:Class ;
-                 rdfs:subClassOf :feeds .
+###  https://w3id.org/fso#TreatmentDevice
+:TreatmentDevice rdf:type owl:Class ;
+                 rdfs:subClassOf :Component ;
+                 rdfs:comment "A device used to change the properties of material flowing through it. For example, filters."@en ;
+                 rdfs:label "Treatment device"@en .
 
 
 #################################################################
@@ -175,28 +335,6 @@
 ###  https://w3id.org/fso#
 <https://w3id.org/fso#> rdf:type owl:NamedIndividual ,
                                  <http://purl.org/vocommons/voaf#Vocabulary> .
-
-
-#################################################################
-#    Annotations
-#################################################################
-
-:feeds rdfs:comment ""@da ,
-                    ""@en ;
-       rdfs:label "feeds"@en ,
-                  "føder"@da .
-
-
-:returnsFluidTo rdfs:comment ""@da ,
-                             ""@en ;
-                rdfs:label "returnerer fluid til"@da ,
-                           "returns fluid to"@en .
-
-
-:suppliesFluidTo rdfs:comment ""@da ,
-                              ""@en ;
-                 rdfs:label "forsyner fluid til"@da ,
-                            "supplies fluid to"@en .
 
 
 ###  Generated by the OWL API (version 5.1.11) https://github.com/owlcs/owlapi/

--- a/docs/ontology.xml
+++ b/docs/ontology.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="https://w3id.org/fso#"
      xml:base="https://w3id.org/fso"
-     xmlns:ns="http://www.w3.org/2003/06/sw-vocab-status/ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:vann="http://purl.org/vocab/vann/"
-     xmlns:terms="http://purl.org/dc/terms/"
-     xmlns:schema="http://schema.org/">
+     xmlns:terms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="https://w3id.org/fso#">
         <owl:versionIRI rdf:resource="https://w3id.org/fso/0.0.1"/>
         <terms:contributor>All contributing members of the W3C Linked Building Data Community Group</terms:contributor>
@@ -105,27 +103,6 @@
     
 
 
-    <!-- http://schema.org/domainIncludes -->
-
-
-    <owl:AnnotationProperty rdf:about="http://schema.org/domainIncludes"/>
-    
-
-
-    <!-- http://schema.org/rangeIncludes -->
-
-
-    <owl:AnnotationProperty rdf:about="http://schema.org/rangeIncludes"/>
-    
-
-
-    <!-- http://www.w3.org/2003/06/sw-vocab-status/ns#term_status -->
-
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"/>
-    
-
-
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -138,16 +115,26 @@
     
 
 
-    <!-- https://w3id.org/fso#fedBy -->
+    <!-- https://w3id.org/fso#exchangesFluidWith -->
 
 
-    <owl:ObjectProperty rdf:about="https://w3id.org/fso#fedBy">
-        <owl:inverseOf rdf:resource="https://w3id.org/fso#feeds"/>
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-        <rdfs:comment xml:lang="da"></rdfs:comment>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
-        <rdfs:label xml:lang="en">fed by</rdfs:label>
-        <rdfs:label xml:lang="da">fødes af</rdfs:label>
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#exchangesFluidWith">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:comment xml:lang="en">Relation between two things which have a fluid exchange connection</rdfs:comment>
+        <rdfs:label xml:lang="en">exchanges fluid with</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#exchangesHeatWith -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#exchangesHeatWith">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:comment xml:lang="en">Relation between two things which have a heat exchange connection</rdfs:comment>
+        <rdfs:label xml:lang="en">exchanges heat with</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -156,7 +143,7 @@
 
 
     <owl:ObjectProperty rdf:about="https://w3id.org/fso#feeds">
-        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#exchangesFluidWith"/>
     </owl:ObjectProperty>
     
 
@@ -165,12 +152,166 @@
 
 
     <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasComponent">
-        <rdfs:domain rdf:resource="https://w3id.org/fso#System"/>
-        <schema:domainIncludes rdf:resource="https://w3id.org/fso#HeatExchanger"/>
-        <rdfs:comment xml:lang="da"></rdfs:comment>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
-        <rdfs:label xml:lang="da">har komponent</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:range rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">Relates a system to a component it contains</rdfs:comment>
         <rdfs:label xml:lang="en">has component</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasDensity -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasDensity">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasProperty"/>
+        <rdfs:comment xml:lang="en">A relation between a system and a its density</rdfs:comment>
+        <rdfs:label xml:lang="en">has density</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasFluid -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasFluid">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:comment xml:lang="en">Relates a system to the fluid it contains</rdfs:comment>
+        <rdfs:label xml:lang="en">has fluid</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasHeatCapacity -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasHeatCapacity">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasProperty"/>
+        <rdfs:comment xml:lang="en">A relation between a thing and its heat capacity</rdfs:comment>
+        <rdfs:label xml:lang="en">has heat capacity</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasMassFlow -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasMassFlow">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasProperty"/>
+        <rdfs:comment xml:lang="en">Relation between a thing and its mass flow rate</rdfs:comment>
+        <rdfs:label xml:lang="en">has mass flow</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasPowerOutput -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasPowerOutput">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasProperty"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasProperty -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasProperty">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:comment xml:lang="en">Relation between a thing and a property intrinsic to it</rdfs:comment>
+        <rdfs:label xml:lang="en">has property</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasReturnSystem -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasReturnSystem">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasSubSystem"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AsymmetricProperty"/>
+        <rdfs:range rdf:resource="https://w3id.org/fso#ReturnSystem"/>
+        <rdfs:comment xml:lang="en">Relation between a system and its return system</rdfs:comment>
+        <rdfs:label xml:lang="en">has return system</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasReturnTemperature -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasReturnTemperature">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasTemperature"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://w3id.org/fso#hasReturnSystem"/>
+            <rdf:Description rdf:about="https://w3id.org/fso#hasTemperature"/>
+        </owl:propertyChainAxiom>
+        <rdfs:comment xml:lang="en">Relation between a system and its return temperature</rdfs:comment>
+        <rdfs:label xml:lang="en">has return temperature</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasSubSystem -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasSubSystem">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AsymmetricProperty"/>
+        <rdfs:domain rdf:resource="https://w3id.org/fso#System"/>
+        <rdfs:range rdf:resource="https://w3id.org/fso#System"/>
+        <rdfs:comment xml:lang="en">Relation between a system and its subsystem</rdfs:comment>
+        <rdfs:label xml:lang="en">has subsystem</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasSupplySystem -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasSupplySystem">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasSubSystem"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AsymmetricProperty"/>
+        <rdfs:range rdf:resource="https://w3id.org/fso#SupplySystem"/>
+        <rdfs:comment xml:lang="en">Relation between a system and its supply system</rdfs:comment>
+        <rdfs:label xml:lang="en">has supply system</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasSupplyTemperature -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasSupplyTemperature">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasTemperature"/>
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://w3id.org/fso#hasSupplySystem"/>
+            <rdf:Description rdf:about="https://w3id.org/fso#hasTemperature"/>
+        </owl:propertyChainAxiom>
+        <rdfs:comment xml:lang="en">Relation between a system and its supply temperature</rdfs:comment>
+        <rdfs:label xml:lang="en">has supply temperature</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#hasTemperature -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#hasTemperature">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#hasProperty"/>
+        <rdfs:comment xml:lang="en">Relation between a thing and its temperature</rdfs:comment>
+        <rdfs:label xml:lang="en">has temperature</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/fso#isMadeOfMaterial -->
+
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#isMadeOfMaterial">
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
+        <rdfs:comment xml:lang="en">Relation between a thing and the material it is made of</rdfs:comment>
+        <rdfs:label xml:lang="en">is made of material</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -178,33 +319,22 @@
     <!-- https://w3id.org/fso#returnsFluidTo -->
 
 
-    <owl:ObjectProperty rdf:about="https://w3id.org/fso#returnsFluidTo"/>
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#returnsFluidTo">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#feeds"/>
+        <rdfs:comment xml:lang="en">Relation of a component that supplies fluid to another component</rdfs:comment>
+        <rdfs:label xml:lang="en">returns fluid to</rdfs:label>
+    </owl:ObjectProperty>
     
 
 
     <!-- https://w3id.org/fso#suppliesFluidTo -->
 
 
-    <owl:ObjectProperty rdf:about="https://w3id.org/fso#suppliesFluidTo"/>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Data properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-    
-
-
-    <!-- http://xmlns.com/foaf/0.1/name -->
-
-
-    <owl:DatatypeProperty rdf:about="http://xmlns.com/foaf/0.1/name"/>
+    <owl:ObjectProperty rdf:about="https://w3id.org/fso#suppliesFluidTo">
+        <rdfs:subPropertyOf rdf:resource="https://w3id.org/fso#feeds"/>
+        <rdfs:comment xml:lang="en">Relation of a component that returns fluid to another component</rdfs:comment>
+        <rdfs:label xml:lang="en">supplies fluid to</rdfs:label>
+    </owl:ObjectProperty>
     
 
 
@@ -227,29 +357,142 @@
     
 
 
-    <!-- http://xmlns.com/foaf/0.1/Person -->
+    <!-- https://w3id.org/fso#Component -->
 
 
-    <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Person"/>
+    <owl:Class rdf:about="https://w3id.org/fso#Component">
+        <rdfs:comment xml:lang="en">A component contained by a fso:System</rdfs:comment>
+        <rdfs:label xml:lang="en">Component</rdfs:label>
+    </owl:Class>
     
 
 
-    <!-- https://w3id.org/fso#Element -->
+    <!-- https://w3id.org/fso#DistributionSystem -->
 
 
-    <owl:Class rdf:about="https://w3id.org/fso#Element"/>
+    <owl:Class rdf:about="https://w3id.org/fso#DistributionSystem">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#System"/>
+        <rdfs:comment xml:lang="en">A system that distributes energy and/or mass</rdfs:comment>
+        <rdfs:label xml:lang="en">Distribution system</rdfs:label>
+    </owl:Class>
     
 
 
-    <!-- https://w3id.org/fso#HeatExchanger -->
+    <!-- https://w3id.org/fso#EnergyConversionDevice -->
 
 
-    <owl:Class rdf:about="https://w3id.org/fso#HeatExchanger">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Element"/>
-        <rdfs:comment xml:lang="en">A heat exchanger is a device designed to transfer energy from one medium to another. Examples of heat exchangers include radiators, heating coils, water/water heat exchangers and mixing plants.</rdfs:comment>
-        <rdfs:comment xml:lang="da">En varmeveksler er en komponent designet til at overføre energi fra et medie til et andet. Eksempler på varmevekslere omfatter radiatorer, varmeflader, vand/vand varmevekslere og blandeanlæg.</rdfs:comment>
-        <rdfs:label xml:lang="en">Heat Exchanger</rdfs:label>
-        <rdfs:label xml:lang="da">Varmeveksler</rdfs:label>
+    <owl:Class rdf:about="https://w3id.org/fso#EnergyConversionDevice">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A device that is used to convert energy from one form to another, or move it from one system to another. Potential examples include motors and heat exhangers.</rdfs:comment>
+        <rdfs:label xml:lang="en">Energy conversion device</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#Fitting -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#Fitting">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A component used to connect segments to each other, or to other components. For example, a junction in a pipe system.</rdfs:comment>
+        <rdfs:label xml:lang="en">Fitting</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#FlowController -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#FlowController">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A device that has the potential to control the flow in a network. For example, valves and dampers.</rdfs:comment>
+        <rdfs:label xml:lang="en">Flow controller</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#FlowMovingDevice -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#FlowMovingDevice">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A device used to induce movement in a network. For example, pumps and fans.</rdfs:comment>
+        <rdfs:label xml:lang="en">Flow moving device</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#Fluid -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#Fluid">
+        <rdfs:comment xml:lang="en">A liquid or gaseous substance, for example water or some mixture</rdfs:comment>
+        <rdfs:label xml:lang="en">Fluid</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#Material -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#Material">
+        <rdfs:comment xml:lang="en">A substance</rdfs:comment>
+        <rdfs:label xml:lang="en">Material</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#MonitoringDevice -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#MonitoringDevice">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter.</rdfs:comment>
+        <rdfs:label xml:lang="en">Fluid monitoring device</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#ReturnSystem -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#ReturnSystem">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#DistributionSystem"/>
+        <rdfs:comment xml:lang="en">A system that returns energy and/or mass from consumers</rdfs:comment>
+        <rdfs:label xml:lang="en">Return system</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#Segment -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#Segment">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A component used to enable the passage of material or energy. For example, pipes and ducts.</rdfs:comment>
+        <rdfs:label xml:lang="en">Segment</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#StorageDevice -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#StorageDevice">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A device used to store mass or energy. For example, a water tank.</rdfs:comment>
+        <rdfs:label xml:lang="en">Storage device</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/fso#SupplySystem -->
+
+
+    <owl:Class rdf:about="https://w3id.org/fso#SupplySystem">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#DistributionSystem"/>
+        <rdfs:comment xml:lang="en">A system that supplies energy and/or mass to consumers</rdfs:comment>
+        <rdfs:label xml:lang="en">Supply system</rdfs:label>
     </owl:Class>
     
 
@@ -258,36 +501,30 @@
 
 
     <owl:Class rdf:about="https://w3id.org/fso#System">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Element"/>
         <rdfs:comment xml:lang="en">A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties.</rdfs:comment>
-        <rdfs:comment xml:lang="da">Et system definerer egenskaber der er gældende for alle komponenter i systemet og fungerer dermed som en grupperingsmekanisme. Typiske systemegenskaber omfatter fluidegenskaber som fluidtype, temperatur og termiske egenskaber.</rdfs:comment>
-        <rdfs:label xml:lang="da">System</rdfs:label>
         <rdfs:label xml:lang="en">System</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- https://w3id.org/fso#feeds -->
+    <!-- https://w3id.org/fso#Terminal -->
 
 
-    <owl:Class rdf:about="https://w3id.org/fso#feeds"/>
-    
-
-
-    <!-- https://w3id.org/fso#returnsFluidTo -->
-
-
-    <owl:Class rdf:about="https://w3id.org/fso#returnsFluidTo">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#feeds"/>
+    <owl:Class rdf:about="https://w3id.org/fso#Terminal">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A component used to allow material flow out of a distribution system. For example, faucets and air vents.</rdfs:comment>
+        <rdfs:label xml:lang="en">Terminal</rdfs:label>
     </owl:Class>
     
 
 
-    <!-- https://w3id.org/fso#suppliesFluidTo -->
+    <!-- https://w3id.org/fso#TreatmentDevice -->
 
 
-    <owl:Class rdf:about="https://w3id.org/fso#suppliesFluidTo">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#feeds"/>
+    <owl:Class rdf:about="https://w3id.org/fso#TreatmentDevice">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/fso#Component"/>
+        <rdfs:comment xml:lang="en">A device used to change the properties of material flowing through it. For example, filters.</rdfs:comment>
+        <rdfs:label xml:lang="en">Treatment device</rdfs:label>
     </owl:Class>
     
 
@@ -310,36 +547,6 @@
     <owl:NamedIndividual rdf:about="https://w3id.org/fso#">
         <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
     </owl:NamedIndividual>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotations
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-
-    <rdf:Description rdf:about="https://w3id.org/fso#feeds">
-        <rdfs:comment xml:lang="da"></rdfs:comment>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
-        <rdfs:label xml:lang="en">feeds</rdfs:label>
-        <rdfs:label xml:lang="da">føder</rdfs:label>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://w3id.org/fso#returnsFluidTo">
-        <rdfs:comment xml:lang="da"></rdfs:comment>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
-        <rdfs:label xml:lang="da">returnerer fluid til</rdfs:label>
-        <rdfs:label xml:lang="en">returns fluid to</rdfs:label>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://w3id.org/fso#suppliesFluidTo">
-        <rdfs:comment xml:lang="da"></rdfs:comment>
-        <rdfs:comment xml:lang="en"></rdfs:comment>
-        <rdfs:label xml:lang="da">forsyner fluid til</rdfs:label>
-        <rdfs:label xml:lang="en">supplies fluid to</rdfs:label>
-    </rdf:Description>
 </rdf:RDF>
 
 

--- a/docs/provenance/provenance-en.html
+++ b/docs/provenance/provenance-en.html
@@ -9,7 +9,7 @@
 <div class="head">
 <h1>Provenance for The Fluid Systems Ontology (FSO) Documentation (https://w3id.org/fso/0.0.1)</h1>
 <ul>
-	<li>Ontology created by: Ali Kücükavci, Mads Holten Rasmussen, Ville Kukkonen</li>	<li>Ontology contributed to by:  All contributing members of the W3C Linked Building Data Community Group</li>
+	<li>Ontology created by: https://orcid.org/0000-0002-6519-7057, Ali Kücükavci, Mads Holten Rasmussen, Ville Kukkonen</li>	<li>Ontology contributed to by:  All contributing members of the W3C Linked Building Data Community Group</li>
 <li>https://w3id.org/fso/0.0.1 is a revision of the previous version https://w3id.org/fso/0.0.1</li>
 <li>The ontology documentation was the result of using the <a href="https://github.com/dgarijo/Widoco">Widoco tool</a> (which itself uses <a href="http://www.essepuntato.it/lode/">LODE</a> for generating the crossreference section).</li>
 <li>The documentation was generated at 2019-11-06T12:00:00</ul>

--- a/docs/provenance/provenance-en.ttl
+++ b/docs/provenance/provenance-en.ttl
@@ -3,6 +3,8 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 <https://w3id.org/fso/0.0.1> a prov:Entity;
 	 dc:title "The Fluid Systems Ontology (FSO)";
+	 prov:wasAttributedTo <https://orcid.org/0000-0002-6519-7057>;
+	 dc:creator <https://orcid.org/0000-0002-6519-7057>;
 	 prov:wasAttributedTo :agent0;
 	 prov:wasAttributedTo :agent1;
 	 prov:wasAttributedTo :agent2;

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -32,18 +32,3 @@ b) Execute Chrome with the following commands :
 (UNX) /usr/bin/google-chrome --allow-file-access-from-files
 
 Do you have a problem? open an issue at https://github.com/dgarijo/Widoco
-
-Implementing changes to the ontology
-==========
-If you do any changes to fso.ttl and want to display it on https://alikucukavci.github.io/FSO/index-en.html, then following steps has to be executed. 
-1. Do your changes in fso.ttl
-2. Open WIDOC.jar desktop app, which you have downloaded
-3. In WIDOC, Select template, change project name to "docs"
-4. In WIDOC, Select template, change create template documentation from URI to "https://raw.githubusercontent.com/alikucukavci/FSO/master/fso.ttl"
-5. In WIDOC, Select template, change project export location to the local repo of FSO
-6. In WIDOC, Load Sections, check all boxes
-7. In WIDOC, Finish, click Finish
-8. In repo, replace the file .htaccess from folder .../FSO/docs with .htaccess from folder .../FSO   
-9. Do git add, commit and push to origin master
-10. Open https://alikucukavci.github.io/FSO/index-en.html and see if your changes are implemented
-

--- a/docs/webvowl/data/ontology.json
+++ b/docs/webvowl/data/ontology.json
@@ -1,8 +1,8 @@
 {
   "_comment" : "Created with OWL2VOWL (version 0.3.5), http://vowl.visualdataweb.org",
   "header" : {
-    "languages" : [ "en", "da", "undefined" ],
-    "baseIris" : [ "http://www.w3.org/1999/02/22-rdf-syntax-ns", "http://purl.org/vocommons/voaf", "http://www.w3.org/2000/01/rdf-schema", "http://www.w3.org/2001/XMLSchema", "https://w3id.org/fso", "http://xmlns.com/foaf/0.1" ],
+    "languages" : [ "en", "undefined" ],
+    "baseIris" : [ "http://www.w3.org/1999/02/22-rdf-syntax-ns", "http://purl.org/vocommons/voaf", "http://www.w3.org/2002/07/owl", "http://www.w3.org/2000/01/rdf-schema", "http://www.w3.org/2001/XMLSchema", "https://w3id.org/fso" ],
     "title" : {
       "en" : "The Fluid Systems Ontology (FSO)"
     },
@@ -38,12 +38,12 @@
       }, {
         "identifier" : "creator",
         "language" : "undefined",
-        "value" : "Ville Kukkonen",
+        "value" : "Ali Kücükavci",
         "type" : "label"
       }, {
         "identifier" : "creator",
         "language" : "undefined",
-        "value" : "Ali Kücükavci",
+        "value" : "Ville Kukkonen",
         "type" : "label"
       } ],
       "contributor" : [ {
@@ -92,28 +92,67 @@
   },
   "namespace" : [ ],
   "class" : [ {
-    "id" : "4",
+    "id" : "5",
     "type" : "owl:Class"
   }, {
-    "id" : "7",
-    "type" : "rdfs:Literal"
+    "id" : "10",
+    "type" : "owl:Class"
+  }, {
+    "id" : "11",
+    "type" : "owl:Class"
   }, {
     "id" : "6",
     "type" : "owl:Class"
   }, {
-    "id" : "5",
+    "id" : "42",
+    "type" : "owl:Class"
+  }, {
+    "id" : "15",
+    "type" : "owl:Class"
+  }, {
+    "id" : "34",
     "type" : "owl:Thing"
+  }, {
+    "id" : "30",
+    "type" : "owl:Thing"
+  }, {
+    "id" : "45",
+    "type" : "owl:Class"
+  }, {
+    "id" : "50",
+    "type" : "owl:Class"
+  }, {
+    "id" : "16",
+    "type" : "owl:Class"
+  }, {
+    "id" : "35",
+    "type" : "owl:Class"
   }, {
     "id" : "1",
     "type" : "owl:Thing"
   }, {
-    "id" : "13",
-    "type" : "owl:Class"
+    "id" : "32",
+    "type" : "owl:Thing"
   }, {
     "id" : "14",
     "type" : "owl:Class"
   }, {
-    "id" : "10",
+    "id" : "17",
+    "type" : "owl:Class"
+  }, {
+    "id" : "18",
+    "type" : "owl:Class"
+  }, {
+    "id" : "19",
+    "type" : "owl:Class"
+  }, {
+    "id" : "20",
+    "type" : "owl:Class"
+  }, {
+    "id" : "21",
+    "type" : "owl:Class"
+  }, {
+    "id" : "31",
     "type" : "owl:Class"
   } ],
   "classAttribute" : [ {
@@ -122,45 +161,53 @@
     "instances" : 0,
     "label" : {
       "IRI-based" : "System",
-      "en" : "System",
-      "da" : "System"
+      "en" : "System"
     },
+    "subClasses" : [ "6" ],
     "comment" : {
-      "en" : "A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties.",
-      "da" : "Et system definerer egenskaber der er gældende for alle komponenter i systemet og fungerer dermed som en grupperingsmekanisme. Typiske systemegenskaber omfatter fluidegenskaber som fluidtype, temperatur og termiske egenskaber."
+      "en" : "A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties."
     },
-    "id" : "4",
-    "superClasses" : [ "6" ]
+    "id" : "5"
   }, {
-    "iri" : "http://www.w3.org/2000/01/rdf-schema#Literal",
-    "id" : "7",
-    "label" : {
-      "IRI-based" : "Literal",
-      "undefined" : "Literal"
-    }
-  }, {
-    "iri" : "https://w3id.org/fso#Element",
+    "iri" : "https://w3id.org/fso#TreatmentDevice",
     "baseIri" : "https://w3id.org/fso",
     "instances" : 0,
     "label" : {
-      "IRI-based" : "Element"
+      "IRI-based" : "TreatmentDevice",
+      "en" : "Treatment device"
     },
-    "subClasses" : [ "4", "10" ],
-    "id" : "6"
+    "comment" : {
+      "en" : "A device used to change the properties of material flowing through it. For example, filters."
+    },
+    "id" : "10",
+    "superClasses" : [ "11" ]
   }, {
-    "iri" : "http://www.w3.org/2002/07/owl#Thing",
-    "baseIri" : "http://owl2vowl.de",
-    "id" : "5",
+    "iri" : "https://w3id.org/fso#Component",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
     "label" : {
-      "undefined" : "Thing"
-    }
+      "IRI-based" : "Component",
+      "en" : "Component"
+    },
+    "subClasses" : [ "14", "15", "10", "16", "17", "18", "19", "20", "21" ],
+    "comment" : {
+      "en" : "A component contained by a fso:System"
+    },
+    "id" : "11"
   }, {
-    "iri" : "http://www.w3.org/2002/07/owl#Thing",
-    "baseIri" : "http://owl2vowl.de",
-    "id" : "1",
+    "iri" : "https://w3id.org/fso#DistributionSystem",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
     "label" : {
-      "undefined" : "Thing"
-    }
+      "IRI-based" : "DistributionSystem",
+      "en" : "Distribution system"
+    },
+    "subClasses" : [ "31", "35" ],
+    "comment" : {
+      "en" : "A system that distributes energy and/or mass"
+    },
+    "id" : "6",
+    "superClasses" : [ "5" ]
   }, {
     "iri" : "http://purl.org/vocommons/voaf#Vocabulary",
     "baseIri" : "http://purl.org/vocommons/voaf",
@@ -174,30 +221,188 @@
       "labels" : { }
     } ],
     "attributes" : [ "external" ],
-    "id" : "13"
+    "id" : "42"
   }, {
-    "iri" : "http://xmlns.com/foaf/0.1/Person",
-    "baseIri" : "http://xmlns.com/foaf/0.1",
-    "instances" : 0,
-    "label" : {
-      "IRI-based" : "Person"
-    },
-    "attributes" : [ "external" ],
-    "id" : "14"
-  }, {
-    "iri" : "https://w3id.org/fso#HeatExchanger",
+    "iri" : "https://w3id.org/fso#StorageDevice",
     "baseIri" : "https://w3id.org/fso",
     "instances" : 0,
     "label" : {
-      "IRI-based" : "HeatExchanger",
-      "en" : "Heat Exchanger",
-      "da" : "Varmeveksler"
+      "IRI-based" : "StorageDevice",
+      "en" : "Storage device"
     },
     "comment" : {
-      "en" : "A heat exchanger is a device designed to transfer energy from one medium to another. Examples of heat exchangers include radiators, heating coils, water/water heat exchangers and mixing plants.",
-      "da" : "En varmeveksler er en komponent designet til at overføre energi fra et medie til et andet. Eksempler på varmevekslere omfatter radiatorer, varmeflader, vand/vand varmevekslere og blandeanlæg."
+      "en" : "A device used to store mass or energy. For example, a water tank."
     },
-    "id" : "10",
+    "id" : "15",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "http://www.w3.org/2002/07/owl#Thing",
+    "baseIri" : "http://owl2vowl.de",
+    "id" : "34",
+    "label" : {
+      "undefined" : "Thing"
+    }
+  }, {
+    "iri" : "http://www.w3.org/2002/07/owl#Thing",
+    "baseIri" : "http://owl2vowl.de",
+    "id" : "30",
+    "label" : {
+      "undefined" : "Thing"
+    }
+  }, {
+    "iri" : "https://w3id.org/fso#Material",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "Material",
+      "en" : "Material"
+    },
+    "comment" : {
+      "en" : "A substance"
+    },
+    "id" : "45"
+  }, {
+    "iri" : "https://w3id.org/fso#Fluid",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "Fluid",
+      "en" : "Fluid"
+    },
+    "comment" : {
+      "en" : "A liquid or gaseous substance, for example water or some mixture"
+    },
+    "id" : "50"
+  }, {
+    "iri" : "https://w3id.org/fso#EnergyConversionDevice",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "EnergyConversionDevice",
+      "en" : "Energy conversion device"
+    },
+    "comment" : {
+      "en" : "A device that is used to convert energy from one form to another, or move it from one system to another. Potential examples include motors and heat exhangers."
+    },
+    "id" : "16",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "https://w3id.org/fso#SupplySystem",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "SupplySystem",
+      "en" : "Supply system"
+    },
+    "comment" : {
+      "en" : "A system that supplies energy and/or mass to consumers"
+    },
+    "id" : "35",
+    "superClasses" : [ "6" ]
+  }, {
+    "iri" : "http://www.w3.org/2002/07/owl#Thing",
+    "baseIri" : "http://owl2vowl.de",
+    "id" : "1",
+    "label" : {
+      "undefined" : "Thing"
+    }
+  }, {
+    "iri" : "http://www.w3.org/2002/07/owl#Thing",
+    "baseIri" : "http://owl2vowl.de",
+    "id" : "32",
+    "label" : {
+      "undefined" : "Thing"
+    }
+  }, {
+    "iri" : "https://w3id.org/fso#MonitoringDevice",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "MonitoringDevice",
+      "en" : "Fluid monitoring device"
+    },
+    "comment" : {
+      "en" : "A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter."
+    },
+    "id" : "14",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "https://w3id.org/fso#Terminal",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "Terminal",
+      "en" : "Terminal"
+    },
+    "comment" : {
+      "en" : "A component used to allow material flow out of a distribution system. For example, faucets and air vents."
+    },
+    "id" : "17",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "https://w3id.org/fso#FlowMovingDevice",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "FlowMovingDevice",
+      "en" : "Flow moving device"
+    },
+    "comment" : {
+      "en" : "A device used to induce movement in a network. For example, pumps and fans."
+    },
+    "id" : "18",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "https://w3id.org/fso#Segment",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "Segment",
+      "en" : "Segment"
+    },
+    "comment" : {
+      "en" : "A component used to enable the passage of material or energy. For example, pipes and ducts."
+    },
+    "id" : "19",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "https://w3id.org/fso#FlowController",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "FlowController",
+      "en" : "Flow controller"
+    },
+    "comment" : {
+      "en" : "A device that has the potential to control the flow in a network. For example, valves and dampers."
+    },
+    "id" : "20",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "https://w3id.org/fso#Fitting",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "Fitting",
+      "en" : "Fitting"
+    },
+    "comment" : {
+      "en" : "A component used to connect segments to each other, or to other components. For example, a junction in a pipe system."
+    },
+    "id" : "21",
+    "superClasses" : [ "11" ]
+  }, {
+    "iri" : "https://w3id.org/fso#ReturnSystem",
+    "baseIri" : "https://w3id.org/fso",
+    "instances" : 0,
+    "label" : {
+      "IRI-based" : "ReturnSystem",
+      "en" : "Return system"
+    },
+    "comment" : {
+      "en" : "A system that returns energy and/or mass from consumers"
+    },
+    "id" : "31",
     "superClasses" : [ "6" ]
   } ],
   "property" : [ {
@@ -207,13 +412,10 @@
     "id" : "3",
     "type" : "owl:objectProperty"
   }, {
-    "id" : "8",
-    "type" : "rdfs:SubClassOf"
+    "id" : "4",
+    "type" : "owl:objectProperty"
   }, {
     "id" : "9",
-    "type" : "rdfs:SubClassOf"
-  }, {
-    "id" : "11",
     "type" : "owl:objectProperty"
   }, {
     "id" : "12",
@@ -222,53 +424,144 @@
     "id" : "2",
     "type" : "owl:objectProperty"
   }, {
-    "id" : "15",
-    "type" : "owl:datatypeProperty"
+    "id" : "23",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "27",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "13",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "29",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "25",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "22",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "33",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "7",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "26",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "28",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "38",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "39",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "40",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "41",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "43",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "44",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "46",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "47",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "48",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "8",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "49",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "51",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "52",
+    "type" : "rdfs:SubClassOf"
+  }, {
+    "id" : "24",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "37",
+    "type" : "owl:objectProperty"
+  }, {
+    "id" : "36",
+    "type" : "owl:objectProperty"
   } ],
   "propertyAttribute" : [ {
-    "iri" : "https://w3id.org/fso#fedBy",
-    "inverse" : "2",
+    "iri" : "https://w3id.org/fso#hasFluid",
     "baseIri" : "https://w3id.org/fso",
     "range" : "1",
     "label" : {
-      "IRI-based" : "fedBy",
-      "en" : "fed by",
-      "da" : "fødes af"
+      "IRI-based" : "hasFluid",
+      "en" : "has fluid"
     },
+    "superproperty" : [ "2" ],
     "domain" : "1",
-    "comment" : { },
-    "attributes" : [ "object", "transitive" ],
+    "comment" : {
+      "en" : "Relates a system to the fluid it contains"
+    },
+    "attributes" : [ "object" ],
     "id" : "0"
   }, {
-    "iri" : "https://w3id.org/fso#hasComponent",
+    "iri" : "https://w3id.org/fso#hasReturnTemperature",
     "baseIri" : "https://w3id.org/fso",
-    "range" : "5",
-    "annotations" : {
-      "domainIncludes" : [ {
-        "identifier" : "domainIncludes",
-        "language" : "undefined",
-        "value" : "https://w3id.org/fso#HeatExchanger",
-        "type" : "iri"
-      } ]
-    },
+    "range" : "1",
     "label" : {
-      "IRI-based" : "hasComponent",
-      "en" : "has component",
-      "da" : "har komponent"
+      "IRI-based" : "hasReturnTemperature",
+      "en" : "has return temperature"
     },
-    "domain" : "4",
-    "comment" : { },
+    "superproperty" : [ "4" ],
+    "domain" : "1",
+    "comment" : {
+      "en" : "Relation between a system and its return temperature"
+    },
     "attributes" : [ "object" ],
     "id" : "3"
   }, {
-    "range" : "6",
-    "domain" : "4",
-    "attributes" : [ "object", "anonymous" ],
-    "id" : "8"
+    "iri" : "https://w3id.org/fso#hasTemperature",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "hasTemperature",
+      "en" : "has temperature"
+    },
+    "superproperty" : [ "7" ],
+    "domain" : "1",
+    "subproperty" : [ "3", "8" ],
+    "comment" : {
+      "en" : "Relation between a thing and its temperature"
+    },
+    "attributes" : [ "object" ],
+    "id" : "4"
   }, {
-    "range" : "6",
-    "domain" : "10",
-    "attributes" : [ "object", "anonymous" ],
+    "iri" : "https://w3id.org/fso#hasDensity",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "hasDensity",
+      "en" : "has density"
+    },
+    "superproperty" : [ "7" ],
+    "domain" : "1",
+    "comment" : {
+      "en" : "A relation between a system and a its density"
+    },
+    "attributes" : [ "object" ],
     "id" : "9"
   }, {
     "iri" : "https://w3id.org/fso#suppliesFluidTo",
@@ -276,48 +569,291 @@
     "range" : "1",
     "label" : {
       "IRI-based" : "suppliesFluidTo",
-      "en" : "supplies fluid to",
-      "da" : "forsyner fluid til"
+      "en" : "supplies fluid to"
+    },
+    "superproperty" : [ "13" ],
+    "domain" : "1",
+    "comment" : {
+      "en" : "Relation of a component that returns fluid to another component"
+    },
+    "attributes" : [ "object" ],
+    "id" : "12"
+  }, {
+    "iri" : "http://www.w3.org/2002/07/owl#topObjectProperty",
+    "baseIri" : "http://www.w3.org/2002/07/owl",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "topObjectProperty"
     },
     "domain" : "1",
-    "comment" : { },
+    "subproperty" : [ "0", "22", "7", "23", "24", "25", "26" ],
+    "attributes" : [ "external", "object" ],
+    "id" : "2"
+  }, {
+    "iri" : "https://w3id.org/fso#exchangesHeatWith",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "exchangesHeatWith",
+      "en" : "exchanges heat with"
+    },
+    "superproperty" : [ "2" ],
+    "domain" : "1",
+    "comment" : {
+      "en" : "Relation between two things which have a heat exchange connection"
+    },
+    "attributes" : [ "symmetric", "object" ],
+    "id" : "23"
+  }, {
+    "iri" : "https://w3id.org/fso#hasMassFlow",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "hasMassFlow",
+      "en" : "has mass flow"
+    },
+    "superproperty" : [ "7" ],
+    "domain" : "1",
+    "comment" : {
+      "en" : "Relation between a thing and its mass flow rate"
+    },
     "attributes" : [ "object" ],
-    "id" : "11"
+    "id" : "27"
+  }, {
+    "iri" : "https://w3id.org/fso#feeds",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "feeds"
+    },
+    "superproperty" : [ "25" ],
+    "domain" : "1",
+    "subproperty" : [ "12", "28" ],
+    "attributes" : [ "object" ],
+    "id" : "13"
+  }, {
+    "iri" : "https://w3id.org/fso#hasReturnSystem",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "31",
+    "label" : {
+      "IRI-based" : "hasReturnSystem",
+      "en" : "has return system"
+    },
+    "superproperty" : [ "24" ],
+    "domain" : "30",
+    "comment" : {
+      "en" : "Relation between a system and its return system"
+    },
+    "attributes" : [ "asymmetric", "object" ],
+    "id" : "29"
+  }, {
+    "iri" : "https://w3id.org/fso#exchangesFluidWith",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "exchangesFluidWith",
+      "en" : "exchanges fluid with"
+    },
+    "superproperty" : [ "2" ],
+    "domain" : "1",
+    "subproperty" : [ "13" ],
+    "comment" : {
+      "en" : "Relation between two things which have a fluid exchange connection"
+    },
+    "attributes" : [ "symmetric", "object" ],
+    "id" : "25"
+  }, {
+    "iri" : "https://w3id.org/fso#hasComponent",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "11",
+    "label" : {
+      "IRI-based" : "hasComponent",
+      "en" : "has component"
+    },
+    "superproperty" : [ "2" ],
+    "domain" : "32",
+    "comment" : {
+      "en" : "Relates a system to a component it contains"
+    },
+    "attributes" : [ "object" ],
+    "id" : "22"
+  }, {
+    "iri" : "https://w3id.org/fso#hasSupplySystem",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "35",
+    "label" : {
+      "IRI-based" : "hasSupplySystem",
+      "en" : "has supply system"
+    },
+    "superproperty" : [ "24" ],
+    "domain" : "34",
+    "comment" : {
+      "en" : "Relation between a system and its supply system"
+    },
+    "attributes" : [ "asymmetric", "object" ],
+    "id" : "33"
+  }, {
+    "iri" : "https://w3id.org/fso#hasProperty",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "hasProperty",
+      "en" : "has property"
+    },
+    "superproperty" : [ "2" ],
+    "domain" : "1",
+    "subproperty" : [ "9", "36", "27", "4", "37" ],
+    "comment" : {
+      "en" : "Relation between a thing and a property intrinsic to it"
+    },
+    "attributes" : [ "object" ],
+    "id" : "7"
+  }, {
+    "iri" : "https://w3id.org/fso#isMadeOfMaterial",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "isMadeOfMaterial",
+      "en" : "is made of material"
+    },
+    "superproperty" : [ "2" ],
+    "domain" : "1",
+    "comment" : {
+      "en" : "Relation between a thing and the material it is made of"
+    },
+    "attributes" : [ "object" ],
+    "id" : "26"
   }, {
     "iri" : "https://w3id.org/fso#returnsFluidTo",
     "baseIri" : "https://w3id.org/fso",
     "range" : "1",
     "label" : {
       "IRI-based" : "returnsFluidTo",
-      "en" : "returns fluid to",
-      "da" : "returnerer fluid til"
+      "en" : "returns fluid to"
     },
+    "superproperty" : [ "13" ],
     "domain" : "1",
-    "comment" : { },
+    "comment" : {
+      "en" : "Relation of a component that supplies fluid to another component"
+    },
     "attributes" : [ "object" ],
-    "id" : "12"
+    "id" : "28"
   }, {
-    "iri" : "https://w3id.org/fso#feeds",
+    "range" : "6",
+    "domain" : "31",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "38"
+  }, {
+    "range" : "11",
+    "domain" : "21",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "39"
+  }, {
+    "range" : "6",
+    "domain" : "35",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "40"
+  }, {
+    "range" : "11",
+    "domain" : "18",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "41"
+  }, {
+    "range" : "11",
+    "domain" : "20",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "43"
+  }, {
+    "range" : "11",
+    "domain" : "19",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "44"
+  }, {
+    "range" : "5",
+    "domain" : "6",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "46"
+  }, {
+    "range" : "11",
+    "domain" : "14",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "47"
+  }, {
+    "range" : "11",
+    "domain" : "15",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "48"
+  }, {
+    "iri" : "https://w3id.org/fso#hasSupplyTemperature",
     "baseIri" : "https://w3id.org/fso",
     "range" : "1",
     "label" : {
-      "IRI-based" : "feeds",
-      "en" : "feeds",
-      "da" : "føder"
+      "IRI-based" : "hasSupplyTemperature",
+      "en" : "has supply temperature"
     },
+    "superproperty" : [ "4" ],
     "domain" : "1",
-    "comment" : { },
-    "attributes" : [ "object", "transitive" ],
-    "id" : "2"
+    "comment" : {
+      "en" : "Relation between a system and its supply temperature"
+    },
+    "attributes" : [ "object" ],
+    "id" : "8"
   }, {
-    "iri" : "http://xmlns.com/foaf/0.1/name",
-    "baseIri" : "http://xmlns.com/foaf/0.1",
-    "range" : "7",
+    "range" : "11",
+    "domain" : "10",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "49"
+  }, {
+    "range" : "11",
+    "domain" : "16",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "51"
+  }, {
+    "range" : "11",
+    "domain" : "17",
+    "attributes" : [ "anonymous", "object" ],
+    "id" : "52"
+  }, {
+    "iri" : "https://w3id.org/fso#hasSubSystem",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "5",
     "label" : {
-      "IRI-based" : "name"
+      "IRI-based" : "hasSubSystem",
+      "en" : "has subsystem"
     },
+    "superproperty" : [ "2" ],
+    "domain" : "5",
+    "subproperty" : [ "33", "29" ],
+    "comment" : {
+      "en" : "Relation between a system and its subsystem"
+    },
+    "attributes" : [ "asymmetric", "object" ],
+    "id" : "24"
+  }, {
+    "iri" : "https://w3id.org/fso#hasHeatCapacity",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "hasHeatCapacity",
+      "en" : "has heat capacity"
+    },
+    "superproperty" : [ "7" ],
     "domain" : "1",
-    "attributes" : [ "external", "datatype" ],
-    "id" : "15"
+    "comment" : {
+      "en" : "A relation between a thing and its heat capacity"
+    },
+    "attributes" : [ "object" ],
+    "id" : "37"
+  }, {
+    "iri" : "https://w3id.org/fso#hasPowerOutput",
+    "baseIri" : "https://w3id.org/fso",
+    "range" : "1",
+    "label" : {
+      "IRI-based" : "hasPowerOutput"
+    },
+    "superproperty" : [ "7" ],
+    "domain" : "1",
+    "attributes" : [ "object" ],
+    "id" : "36"
   } ]
 }

--- a/fso.ttl
+++ b/fso.ttl
@@ -1,244 +1,350 @@
 @prefix : <https://w3id.org/fso#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix bot: <https://w3id.org/bot#> .
+@prefix dbo: <http://dbpedia.org/ontology/> .
+@prefix dce: <http://purl.org/dc/elements/1.1/> .
+@prefix fso: <https://w3id.org/fso#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix schema: <http://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @base <https://w3id.org/fso#> .
 
-<https://w3id.org/fso#> rdf:type owl:Ontology .
+<https://w3id.org/fso#> rdf:type owl:Ontology ;
+                         owl:versionIRI <https://w3id.org/fso/0.0.1> ;
+                         dcterms:contributor "All contributing members of the W3C Linked Building Data Community Group" ;
+                         dcterms:creator <https://orcid.org/0000-0002-6519-7057> ,
+                                         "Ali Kücükavci" ,
+                                         "Mads Holten Rasmussen" ,
+                                         "Ville Kukkonen" ;
+                         dcterms:description "Some description in english"@en ;
+                         dcterms:issued "2020-01-01T12:00:00"^^xsd:dateTime ;
+                         dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
+                         dcterms:modified "2019-11-06T12:00:00"^^xsd:dateTime ;
+                         dcterms:title "The Fluid Systems Ontology (FSO)"@en ;
+                         vann:preferredNamespacePrefix "fso" ;
+                         vann:preferredNamespaceUri <https://w3id.org/fso#> ;
+                         owl:priorVersion <https://w3id.org/fso/0.0.1> ;
+                         owl:versionInfo "0.0.1" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/terms/contributor
+dcterms:contributor rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/creator
+dcterms:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/description
+dcterms:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/issued
+dcterms:issued rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+dcterms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/modified
+dcterms:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/title
+dcterms:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceUri
+vann:preferredNamespaceUri rdf:type owl:AnnotationProperty .
+
 
 #################################################################
 #    Object Properties
 #################################################################
 
-###  http://www.semanticweb.org/vku/ontologies/2019/10/untitled-ontology-7#feeds
-<http://www.semanticweb.org/vku/ontologies/2019/10/untitled-ontology-7#feeds> rdf:type owl:ObjectProperty ;
-                                                                              rdfs:subPropertyOf :exchangesFluidWith .
-
-
 ###  https://w3id.org/fso#exchangesFluidWith
-:exchangesFluidWith rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf owl:topObjectProperty ;
-                    rdf:type owl:SymmetricProperty ;
-                    rdfs:comment "Relation between two things which have a fluid exchange connection"@en ;
-                    rdfs:label "exchanges fluid with"@en .
+fso:exchangesFluidWith rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf owl:topObjectProperty ;
+                       rdf:type owl:SymmetricProperty ;
+                       rdfs:comment "Relation between two things which have a fluid exchange connection"@en ;
+                       rdfs:label "exchanges fluid with"@en .
 
 
 ###  https://w3id.org/fso#exchangesHeatWith
-:exchangesHeatWith rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf owl:topObjectProperty ;
-                   rdf:type owl:SymmetricProperty ;
-                   rdfs:comment "Relation between two things which have a heat exchange connection"@en ;
-                   rdfs:label "exchanges heat with"@en .
+fso:exchangesHeatWith rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf owl:topObjectProperty ;
+                      rdf:type owl:SymmetricProperty ;
+                      rdfs:comment "Relation between two things which have a heat exchange connection"@en ;
+                      rdfs:label "exchanges heat with"@en .
+
+
+###  https://w3id.org/fso#feeds
+fso:feeds rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf fso:exchangesFluidWith .
 
 
 ###  https://w3id.org/fso#hasComponent
-:hasComponent rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :hasSubSystem ;
-              rdfs:range :Component ;
-              rdfs:comment "Relates a system to a component it contains"@en ;
-              rdfs:label "has component"@en .
+fso:hasComponent rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
+                 rdfs:range fso:Component ;
+                 rdfs:comment "Relates a system to a component it contains"@en ;
+                 rdfs:label "has component"@en .
 
 
 ###  https://w3id.org/fso#hasDensity
-:hasDensity rdf:type owl:ObjectProperty ;
-            rdfs:subPropertyOf :hasProperty ;
-            rdfs:comment "A relation between a system and a its density"@en ;
-            rdfs:label "has density"@en .
+fso:hasDensity rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf fso:hasProperty ;
+               rdfs:comment "A relation between a system and a its density"@en ;
+               rdfs:label "has density"@en .
 
 
 ###  https://w3id.org/fso#hasFluid
-:hasFluid rdf:type owl:ObjectProperty ;
-          rdfs:subPropertyOf owl:topObjectProperty ;
-          rdfs:comment "Relates a system to the fluid it contains"@en ;
-          rdfs:label "has fluid"@en .
+fso:hasFluid rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf owl:topObjectProperty ;
+             rdfs:comment "Relates a system to the fluid it contains"@en ;
+             rdfs:label "has fluid"@en .
 
 
 ###  https://w3id.org/fso#hasHeatCapacity
-:hasHeatCapacity rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf :hasProperty ;
-                 rdfs:comment "A relation between a thing and its heat capacity"@en ;
-                 rdfs:label "has heat capacity"@en .
+fso:hasHeatCapacity rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf fso:hasProperty ;
+                    rdfs:comment "A relation between a thing and its heat capacity"@en ;
+                    rdfs:label "has heat capacity"@en .
 
 
 ###  https://w3id.org/fso#hasMassFlow
-:hasMassFlow rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf :hasProperty ;
-             rdfs:comment "Relation between a thing and its mass flow rate"@en ;
-             rdfs:label "has mass flow"@en .
+fso:hasMassFlow rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf fso:hasProperty ;
+                rdfs:comment "Relation between a thing and its mass flow rate"@en ;
+                rdfs:label "has mass flow"@en .
 
 
 ###  https://w3id.org/fso#hasPowerOutput
-:hasPowerOutput rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf :hasProperty .
+fso:hasPowerOutput rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf fso:hasProperty .
 
 
 ###  https://w3id.org/fso#hasProperty
-:hasProperty rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf owl:topObjectProperty ;
-             rdfs:comment "Relation between a thing and a property intrinsic to it"@en ;
-             rdfs:label "has property"@en .
+fso:hasProperty rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                rdfs:comment "Relation between a thing and a property intrinsic to it"@en ;
+                rdfs:label "has property"@en .
 
 
 ###  https://w3id.org/fso#hasReturnSystem
-:hasReturnSystem rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf :hasSubSystem ;
-                 rdfs:range :ReturnSystem ;
-                 rdfs:comment "Relation between a system and its return system"@en ;
-                 rdfs:label "has return system"@en .
+fso:hasReturnSystem rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf fso:hasSubSystem ;
+                    rdf:type owl:AsymmetricProperty ;
+                    rdfs:range fso:ReturnSystem ;
+                    rdfs:comment "Relation between a system and its return system"@en ;
+                    rdfs:label "has return system"@en .
 
 
 ###  https://w3id.org/fso#hasReturnTemperature
-:hasReturnTemperature rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf :hasTemperature ;
-                      owl:propertyChainAxiom ( :hasReturnSystem
-                                               :hasTemperature
-                                             ) ;
-                      rdfs:comment "Relation between a system and its return temperature"@en ;
-                      rdfs:label "has return temperature"@en .
+fso:hasReturnTemperature rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf fso:hasTemperature ;
+                         owl:propertyChainAxiom ( fso:hasReturnSystem
+                                                  fso:hasTemperature
+                                                ) ;
+                         rdfs:comment "Relation between a system and its return temperature"@en ;
+                         rdfs:label "has return temperature"@en .
 
 
 ###  https://w3id.org/fso#hasSubSystem
-:hasSubSystem rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf owl:topObjectProperty ;
-              rdfs:domain :HVACSystem ;
-              rdfs:range :HVACSystem ;
-              rdfs:comment "Relation between a system and its subsystem"@en ;
-              rdfs:label "has subsystem"@en .
+fso:hasSubSystem rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf owl:topObjectProperty ;
+                 rdf:type owl:AsymmetricProperty ;
+                 rdfs:domain fso:System ;
+                 rdfs:range fso:System ;
+                 rdfs:comment "Relation between a system and its subsystem"@en ;
+                 rdfs:label "has subsystem"@en .
 
 
 ###  https://w3id.org/fso#hasSupplySystem
-:hasSupplySystem rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf :hasSubSystem ;
-                 rdfs:range :SupplySystem ;
-                 rdfs:comment "Relation between a system and its supply system"@en ;
-                 rdfs:label "has supply system"@en .
+fso:hasSupplySystem rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf fso:hasSubSystem ;
+                    rdf:type owl:AsymmetricProperty ;
+                    rdfs:range fso:SupplySystem ;
+                    rdfs:comment "Relation between a system and its supply system"@en ;
+                    rdfs:label "has supply system"@en .
 
 
 ###  https://w3id.org/fso#hasSupplyTemperature
-:hasSupplyTemperature rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf :hasTemperature ;
-                      owl:propertyChainAxiom ( :hasSupplySystem
-                                               :hasTemperature
-                                             ) ;
-                      rdfs:comment "Relation between a system and its supply temperature"@en ;
-                      rdfs:label "has supply temperature"@en .
+fso:hasSupplyTemperature rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf fso:hasTemperature ;
+                         owl:propertyChainAxiom ( fso:hasSupplySystem
+                                                  fso:hasTemperature
+                                                ) ;
+                         rdfs:comment "Relation between a system and its supply temperature"@en ;
+                         rdfs:label "has supply temperature"@en .
 
 
 ###  https://w3id.org/fso#hasTemperature
-:hasTemperature rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf :hasProperty ;
-                rdfs:comment "Relation between a thing and its temperature"@en ;
-                rdfs:label "has temperature"@en .
+fso:hasTemperature rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf fso:hasProperty ;
+                   rdfs:comment "Relation between a thing and its temperature"@en ;
+                   rdfs:label "has temperature"@en .
 
 
 ###  https://w3id.org/fso#isMadeOfMaterial
-:isMadeOfMaterial rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf owl:topObjectProperty ;
-                  rdfs:comment "Relation between a thing and the material it is made of"@en ;
-                  rdfs:label "is made of material"@en .
+fso:isMadeOfMaterial rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf owl:topObjectProperty ;
+                     rdfs:comment "Relation between a thing and the material it is made of"@en ;
+                     rdfs:label "is made of material"@en .
 
 
 ###  https://w3id.org/fso#returnsFluidTo
-:returnsFluidTo rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf <http://www.semanticweb.org/vku/ontologies/2019/10/untitled-ontology-7#feeds> ;
-                rdfs:comment "Relation of a component that supplies fluid to another component"@en ;
-                rdfs:label "returns fluid to"@en .
+fso:returnsFluidTo rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf fso:feeds ;
+                   rdfs:comment "Relation of a component that supplies fluid to another component"@en ;
+                   rdfs:label "returns fluid to"@en .
 
 
 ###  https://w3id.org/fso#suppliesFluidTo
-:suppliesFluidTo rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf <http://www.semanticweb.org/vku/ontologies/2019/10/untitled-ontology-7#feeds> ;
-                 rdfs:comment "Relation of a component that returns fluid to another component"@en ;
-                 rdfs:label "supplies fluid to"@en .
+fso:suppliesFluidTo rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf fso:feeds ;
+                    rdfs:comment "Relation of a component that returns fluid to another component"@en ;
+                    rdfs:label "supplies fluid to"@en .
 
 
 #################################################################
 #    Classes
 #################################################################
 
+###  http://purl.org/vocommons/voaf#Vocabulary
+voaf:Vocabulary rdf:type owl:Class .
+
+
 ###  https://w3id.org/fso#Component
-:Component rdf:type owl:Class ;
-           rdfs:comment "A component contained by a HVAC system"@en ;
-           rdfs:label "Component"@en .
+fso:Component rdf:type owl:Class ;
+              rdfs:comment "A component contained by a fso:System"@en ;
+              rdfs:label "Component"@en .
 
 
 ###  https://w3id.org/fso#DistributionSystem
-:DistributionSystem rdf:type owl:Class ;
-                    rdfs:subClassOf :HVACSystem .
+fso:DistributionSystem rdf:type owl:Class ;
+                       rdfs:subClassOf fso:System ;
+                       rdfs:comment "A system that distributes energy and/or mass"@en ;
+                       rdfs:label "Distribution system"@en .
 
 
 ###  https://w3id.org/fso#EnergyConversionDevice
-:EnergyConversionDevice rdf:type owl:Class ;
-                        rdfs:subClassOf :Component .
+fso:EnergyConversionDevice rdf:type owl:Class ;
+                           rdfs:subClassOf fso:Component ;
+                           rdfs:comment "A device that is used to convert energy from one form to another, or move it from one system to another. Potential examples include motors and heat exhangers."@en ;
+                           rdfs:label "Energy conversion device"@en .
 
 
 ###  https://w3id.org/fso#Fitting
-:Fitting rdf:type owl:Class ;
-         rdfs:subClassOf :Component .
+fso:Fitting rdf:type owl:Class ;
+            rdfs:subClassOf fso:Component ;
+            rdfs:comment "A component used to connect segments to each other, or to other components. For example, a junction in a pipe system."@en ;
+            rdfs:label "Fitting"@en .
 
 
 ###  https://w3id.org/fso#FlowController
-:FlowController rdf:type owl:Class ;
-                rdfs:subClassOf :Component .
+fso:FlowController rdf:type owl:Class ;
+                   rdfs:subClassOf fso:Component ;
+                   rdfs:comment "A device that has the potential to control the flow in a network. For example, valves and dampers."@en ;
+                   rdfs:label "Flow controller"@en .
 
 
 ###  https://w3id.org/fso#FlowMovingDevice
-:FlowMovingDevice rdf:type owl:Class ;
-                  rdfs:subClassOf :Component .
+fso:FlowMovingDevice rdf:type owl:Class ;
+                     rdfs:subClassOf fso:Component ;
+                     rdfs:comment "A device used to induce movement in a network. For example, pumps and fans."@en ;
+                     rdfs:label "Flow moving device"@en .
 
 
 ###  https://w3id.org/fso#Fluid
-:Fluid rdf:type owl:Class ;
-       rdfs:comment "A liquid or gaseous substance, for example water or some mixture"@en ;
-       rdfs:label "Fluid"@en .
-
-
-###  https://w3id.org/fso#FluidMonitoringDevice
-:FluidMonitoringDevice rdf:type owl:Class ;
-                       rdfs:subClassOf :Component .
-
-
-###  https://w3id.org/fso#HVACSystem
-:HVACSystem rdf:type owl:Class ;
-            rdfs:comment ""@en ;
-            rdfs:label "System"@en .
+fso:Fluid rdf:type owl:Class ;
+          rdfs:comment "A liquid or gaseous substance, for example water or some mixture"@en ;
+          rdfs:label "Fluid"@en .
 
 
 ###  https://w3id.org/fso#Material
-:Material rdf:type owl:Class ;
-          rdfs:comment "A substance"@en ;
-          rdfs:label "Material"@en .
+fso:Material rdf:type owl:Class ;
+             rdfs:comment "A substance"@en ;
+             rdfs:label "Material"@en .
+
+
+###  https://w3id.org/fso#MonitoringDevice
+fso:MonitoringDevice rdf:type owl:Class ;
+                     rdfs:subClassOf fso:Component ;
+                     rdfs:comment "A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter."@en ;
+                     rdfs:label "Fluid monitoring device"@en .
 
 
 ###  https://w3id.org/fso#ReturnSystem
-:ReturnSystem rdf:type owl:Class ;
-              rdfs:subClassOf :DistributionSystem ;
-              rdfs:comment "A system used to return fluid from buildings"@en ;
-              rdfs:label "Return system"@en .
+fso:ReturnSystem rdf:type owl:Class ;
+                 rdfs:subClassOf fso:DistributionSystem ;
+                 rdfs:comment "A system that returns energy and/or mass from consumers"@en ;
+                 rdfs:label "Return system"@en .
 
 
 ###  https://w3id.org/fso#Segment
-:Segment rdf:type owl:Class ;
-         rdfs:subClassOf :Component .
+fso:Segment rdf:type owl:Class ;
+            rdfs:subClassOf fso:Component ;
+            rdfs:comment "A component used to enable the passage of material or energy. For example, pipes and ducts."@en ;
+            rdfs:label "Segment"@en .
+
+
+###  https://w3id.org/fso#StorageDevice
+fso:StorageDevice rdf:type owl:Class ;
+                  rdfs:subClassOf fso:Component ;
+                  rdfs:comment "A device used to store mass or energy. For example, a water tank."@en ;
+                  rdfs:label "Storage device"@en .
 
 
 ###  https://w3id.org/fso#SupplySystem
-:SupplySystem rdf:type owl:Class ;
-              rdfs:subClassOf :DistributionSystem ;
-              rdfs:comment "A system used to provide a fluid to buildings"@en ;
-              rdfs:label "Supply system"@en .
+fso:SupplySystem rdf:type owl:Class ;
+                 rdfs:subClassOf fso:DistributionSystem ;
+                 rdfs:comment "A system that supplies energy and/or mass to consumers"@en ;
+                 rdfs:label "Supply system"@en .
+
+
+###  https://w3id.org/fso#System
+fso:System rdf:type owl:Class ;
+           rdfs:comment "A system is a placeholder for properties that are valid for the components of the system and hence serves as an aggregation function. Common system properties include fluid properties such as the fluid type, temperature and thermal properties."@en ;
+           rdfs:label "System"@en .
 
 
 ###  https://w3id.org/fso#Terminal
-:Terminal rdf:type owl:Class ;
-          rdfs:subClassOf :Component .
+fso:Terminal rdf:type owl:Class ;
+             rdfs:subClassOf fso:Component ;
+             rdfs:comment "A component used to allow material flow out of a distribution system. For example, faucets and air vents."@en ;
+             rdfs:label "Terminal"@en .
 
 
 ###  https://w3id.org/fso#TreatmentDevice
-:TreatmentDevice rdf:type owl:Class ;
-                 rdfs:subClassOf :Component .
+fso:TreatmentDevice rdf:type owl:Class ;
+                    rdfs:subClassOf fso:Component ;
+                    rdfs:comment "A device used to change the properties of material flowing through it. For example, filters."@en ;
+                    rdfs:label "Treatment device"@en .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  https://w3id.org/fso#
+<https://w3id.org/fso#> rdf:type owl:NamedIndividual ,
+                                 voaf:Vocabulary .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
Added metadata from previous version. Added initial labels and descriptions for some more classes.

The properties will still need to be trimmed down, I didn't yet go through them.

From what I can tell, the `Component` subclasses should be general enough to cover electrical networks in addition to fluid systems.