### PR TITLE
Remove mentions of MonitoringDevice

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,6 @@
           <a href="#Fitting">fso:Fitting</a>, 
           <a href="#FlowController">fso:FlowController</a>, 
           <a href="#FlowMovingDevice">fso:FlowMovingDevice</a>, 
-          <a href="#MonitoringDevice">fso:MonitoringDevice</a>, 
           <a href="#Segment">fso:Segment</a>, 
           <a href="#StorageDevice">fso:StorageDevice</a>, 
           <a href="#Terminal">fso:Terminal</a>, 
@@ -413,20 +412,6 @@
             <h2>fso:FlowMovingDevice ⊑ fso:Component</h2>
             <p><strong>IRI</strong> <code>https://w3id.org/fso#FlowMovingDevice</code></p>
             <p>A device used to induce movement in a network. For example, pumps and fans.</p>
-            <table>
-              <tbody>
-                <tr>
-                  <th>Sub class of</th>
-                  <td><a href="#Component">fso:Component</a></td>
-                </tr>
-              </tbody>
-            </table>
-          </section>
-
-          <section id="MonitoringDevice">
-            <h2>fso:MonitoringDevice ⊑ fso:Component</h2>
-            <p><strong>IRI</strong> <code>https://w3id.org/fso#MonitoringDevice</code></p>
-            <p>A device used to monitor some property or properties of the distributed thing. For example, a fluid flow meter.</p>
             <table>
               <tbody>
                 <tr>


### PR DESCRIPTION
These were accidentally left in, as they were supposed to be removed after aligning with SAREF4BLDG.